### PR TITLE
[FEAT] 단어장 목록 페이지 UI 작업

### DIFF
--- a/src/components/atoms/BottomNav/types.ts
+++ b/src/components/atoms/BottomNav/types.ts
@@ -1,4 +1,5 @@
 import * as Icons from '@mynaui/icons-react';
+import { ROUTES } from '../../../router/path';
 
 export type BOTTOM_NAV_KEY = 'home' | 'word-book' | 'setting';
 
@@ -20,19 +21,19 @@ export type BOTTOM_NAV_ITEM = {
 export const BOTTOM_NAV_MAPPER: Record<BOTTOM_NAV_KEY, BOTTOM_NAV_ITEM> = {
   home: {
     navKey: 'home',
-    path: '/',
+    path: ROUTES.HOME,
     status: 'ready',
     icon: 'Lock',
   },
   'word-book': {
     navKey: 'word-book',
-    path: '/wordbook',
+    path: ROUTES.WORDBOOKS,
     status: 'ready',
     icon: 'BookOpen',
   },
   setting: {
     navKey: 'setting',
-    path: '/setting',
+    path: ROUTES.SETTING,
     status: 'ready',
     icon: 'User',
   },

--- a/src/components/molecules/WordbookItem/WordbookItem.stories.tsx
+++ b/src/components/molecules/WordbookItem/WordbookItem.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { WordbookItem } from './WordbookItem';
+
+const meta: Meta<typeof WordbookItem> = {
+  title: 'Components/WordbookItem',
+  component: WordbookItem,
+  decorators: [
+    (Story) => (
+      <div style={{ background: '#eeeeee', padding: '24px', minHeight: '100vh' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof WordbookItem>;
+
+export const Default: Story = {
+  args: {
+    name: 'Day 1 Vocabulary',
+    caption: '기초 단어 20개 정리',
+    handleNavigate: () => {
+      console.log('Navigate: Day 1 Vocabulary');
+    },
+  },
+};
+
+export const LongText: Story = {
+  args: {
+    name: 'Advanced Vocabulary Collection',
+    caption: '긴 캡션 테스트용입니다. 여러 줄 설명을 렌더링하여 UI가 깨지지 않는지 확인하세요.',
+    handleNavigate: () => {
+      console.log('Navigate: Advanced Vocabulary');
+    },
+  },
+};
+
+export const Another: Story = {
+  args: {
+    name: '영어 회화 주제별 단어장',
+    caption: '카페/식당/여행 관련 주제별 단어 목록',
+    handleNavigate: () => {
+      console.log('Navigate: Conversation Wordbook');
+    },
+  },
+};

--- a/src/components/molecules/WordbookItem/WordbookItem.stories.tsx
+++ b/src/components/molecules/WordbookItem/WordbookItem.stories.tsx
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof WordbookItem>;
 
 export const Default: Story = {
   args: {
-    name: 'Day 1 Vocabulary',
+    title: 'Day 1 Vocabulary',
     caption: '기초 단어 20개 정리',
     handleNavigate: () => {
       console.log('Navigate: Day 1 Vocabulary');
@@ -29,7 +29,7 @@ export const Default: Story = {
 
 export const LongText: Story = {
   args: {
-    name: 'Advanced Vocabulary Collection',
+    title: 'Advanced Vocabulary Collection',
     caption: '긴 캡션 테스트용입니다. 여러 줄 설명을 렌더링하여 UI가 깨지지 않는지 확인하세요.',
     handleNavigate: () => {
       console.log('Navigate: Advanced Vocabulary');
@@ -39,7 +39,7 @@ export const LongText: Story = {
 
 export const Another: Story = {
   args: {
-    name: '영어 회화 주제별 단어장',
+    title: '영어 회화 주제별 단어장',
     caption: '카페/식당/여행 관련 주제별 단어 목록',
     handleNavigate: () => {
       console.log('Navigate: Conversation Wordbook');

--- a/src/components/molecules/WordbookItem/WordbookItem.tsx
+++ b/src/components/molecules/WordbookItem/WordbookItem.tsx
@@ -10,9 +10,9 @@ export const WordbookItem = ({ title: name, caption, handleNavigate }: Props) =>
   return (
     <div className="flex h-[4.5rem] shrink-0 items-center justify-between rounded-4xl bg-white pr-[0.75rem] pl-[1.5rem]">
       {/* Text */}
-      <div className="flex flex-col">
-        <div className="text-xl">{name}</div>
-        <div className="text-xs text-gray-700">{caption}</div>
+      <div className="flex min-w-0 flex-col">
+        <div className="truncate text-xl">{name}</div>
+        <div className="truncate text-xs text-gray-700">{caption}</div>
       </div>
       {/* Action */}
       <div>

--- a/src/components/molecules/WordbookItem/WordbookItem.tsx
+++ b/src/components/molecules/WordbookItem/WordbookItem.tsx
@@ -16,7 +16,7 @@ export const WordbookItem = ({ title: name, caption, handleNavigate }: Props) =>
       </div>
       {/* Action */}
       <div>
-        <button onClick={() => handleNavigate}>
+        <button onClick={handleNavigate}>
           <Icon name="ChevronRight" color="#B4E35A" />
         </button>
       </div>

--- a/src/components/molecules/WordbookItem/WordbookItem.tsx
+++ b/src/components/molecules/WordbookItem/WordbookItem.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 export const WordbookItem = ({ title: name, caption, handleNavigate }: Props) => {
   return (
-    <div className="flex h-18 items-center justify-between rounded-4xl bg-white pr-3 pl-6">
+    <div className="flex h-[4.5rem] shrink-0 items-center justify-between rounded-4xl bg-white pr-[0.75rem] pl-[1.5rem]">
       {/* Text */}
       <div className="flex flex-col">
         <div className="text-xl">{name}</div>

--- a/src/components/molecules/WordbookItem/WordbookItem.tsx
+++ b/src/components/molecules/WordbookItem/WordbookItem.tsx
@@ -23,8 +23,3 @@ export const WordbookItem = ({ title: name, caption, handleNavigate }: Props) =>
     </div>
   );
 };
-
-/*
-  # 개선 여지
-  - handleClick 의 조립 위치 -> 상위 컴포넌트로 이동 가능
-*/

--- a/src/components/molecules/WordbookItem/WordbookItem.tsx
+++ b/src/components/molecules/WordbookItem/WordbookItem.tsx
@@ -1,12 +1,12 @@
 import { Icon } from '../../atoms/Icon/Icon';
 
 type Props = {
-  name: string;
+  title: string;
   caption: string;
   handleNavigate: () => void;
 };
 
-export const WordbookItem = ({ name, caption, handleNavigate }: Props) => {
+export const WordbookItem = ({ title: name, caption, handleNavigate }: Props) => {
   return (
     <div className="flex h-18 items-center justify-between rounded-4xl bg-white pr-3 pl-6">
       {/* Text */}

--- a/src/components/molecules/WordbookItem/WordbookItem.tsx
+++ b/src/components/molecules/WordbookItem/WordbookItem.tsx
@@ -1,0 +1,30 @@
+import { Icon } from '../../atoms/Icon/Icon';
+
+type Props = {
+  name: string;
+  caption: string;
+  handleNavigate: () => void;
+};
+
+export const WordbookItem = ({ name, caption, handleNavigate }: Props) => {
+  return (
+    <div className="flex h-18 items-center justify-between rounded-4xl bg-white pr-3 pl-6">
+      {/* Text */}
+      <div className="flex flex-col">
+        <div className="text-xl">{name}</div>
+        <div className="text-xs text-gray-700">{caption}</div>
+      </div>
+      {/* Action */}
+      <div>
+        <button onClick={() => handleNavigate}>
+          <Icon name="ChevronRight" color="#B4E35A" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+/*
+  # 개선 여지
+  - handleClick 의 조립 위치 -> 상위 컴포넌트로 이동 가능
+*/

--- a/src/components/organisms/BottomNavBar/BottomNavbar.tsx
+++ b/src/components/organisms/BottomNavBar/BottomNavbar.tsx
@@ -1,5 +1,6 @@
 import { BottomNavItem } from '../../atoms/BottomNav/BottomNavItem';
 import { useLocation } from 'react-router-dom';
+import { ROUTES } from '../../../router/path';
 
 const BottomNavbar = () => {
   const location = useLocation();
@@ -7,9 +8,9 @@ const BottomNavbar = () => {
 
   return (
     <div className="flex h-[4rem] items-center justify-around">
-      <BottomNavItem status="not-ready" selected={path === '/'} navKey="home" />
-      <BottomNavItem status="active" selected={path === '/wordbook'} navKey="word-book" />
-      <BottomNavItem status="active" selected={path === '/setting'} navKey="setting" />
+      <BottomNavItem status="not-ready" selected={path === ROUTES.HOME} navKey="home" />
+      <BottomNavItem status="active" selected={path === ROUTES.WORDBOOKS} navKey="word-book" />
+      <BottomNavItem status="active" selected={path === ROUTES.SETTING} navKey="setting" />
     </div>
   );
 };

--- a/src/components/organisms/TabSwitcher.tsx
+++ b/src/components/organisms/TabSwitcher.tsx
@@ -17,7 +17,7 @@ type Props = {
 
 const TabSwitcher = ({ tabs, activeTab, onChange }: Props) => {
   return (
-    <div className="flex h-[40px] w-full items-center justify-center gap-[12px] rounded-full bg-white px-[12px] py-[6px]">
+    <div className="flex h-[2.5rem] w-full items-center justify-center gap-[0.75rem] rounded-full bg-white px-[0.75rem] py-[o.375rem]">
       {tabs.map((tab, index) => (
         <TabItem
           key={index}

--- a/src/components/organisms/WordbookList/WordbookList.stories.tsx
+++ b/src/components/organisms/WordbookList/WordbookList.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { WordbookList } from './WordbookList';
+
+const meta: Meta<typeof WordbookList> = {
+  title: 'Components/WordbookList',
+  component: WordbookList,
+  decorators: (Story) => (
+    <div style={{ background: '#EEEEEE' }}>
+      <Story />
+    </div>
+  ),
+};
+
+export default meta;
+
+type Story = StoryObj<typeof WordbookList>;
+
+export const Default: Story = {
+  args: {
+    wordbooks: [
+      { id: 1, title: 'Day 1 - Basics', caption: '기초 단어 20개' },
+      { id: 2, title: 'Day 2 - Verbs', caption: '동사 중심 구성' },
+      { id: 3, title: 'Day 3 - Travel', caption: '여행 단어 모음' },
+    ],
+    handleNavigate: (id: number) => {
+      console.log(`Navigate wordbook: ${id}`);
+    },
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    wordbooks: [],
+    handleNavigate: (id: number) => {
+      console.log(`Navigate: ${id}`);
+    },
+  },
+};
+
+export const ManyItems: Story = {
+  args: {
+    wordbooks: Array.from({ length: 10 }).map((_, i) => ({
+      id: i + 1,
+      title: `Wordbook #${i + 1}`,
+      caption: `캡션 테스트 ${i + 1}`,
+    })),
+    handleNavigate: (id: number) => {
+      console.log(`Navigate: ${id}`);
+    },
+  },
+};

--- a/src/components/organisms/WordbookList/WordbookList.stories.tsx
+++ b/src/components/organisms/WordbookList/WordbookList.stories.tsx
@@ -4,11 +4,13 @@ import { WordbookList } from './WordbookList';
 const meta: Meta<typeof WordbookList> = {
   title: 'Components/WordbookList',
   component: WordbookList,
-  decorators: (Story) => (
-    <div style={{ background: '#EEEEEE' }}>
-      <Story />
-    </div>
-  ),
+  decorators: [
+    (Story) => (
+      <div style={{ background: '#EEEEEE' }}>
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export default meta;

--- a/src/components/organisms/WordbookList/WordbookList.tsx
+++ b/src/components/organisms/WordbookList/WordbookList.tsx
@@ -13,7 +13,7 @@ type Props = {
 
 export const WordbookList = ({ wordbooks, handleNavigate }: Props) => {
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex w-full flex-col gap-[1rem]">
       {wordbooks.map((wordbook) => (
         <WordbookItem
           key={wordbook.id}

--- a/src/components/organisms/WordbookList/WordbookList.tsx
+++ b/src/components/organisms/WordbookList/WordbookList.tsx
@@ -1,0 +1,27 @@
+import { WordbookItem } from '../../molecules/WordbookItem/WordbookItem';
+
+type WordbookLabel = {
+  id: number;
+  title: string;
+  caption: string;
+};
+
+type Props = {
+  wordbooks: WordbookLabel[];
+  handleNavigate: (id: number) => void;
+};
+
+export const WordbookList = ({ wordbooks, handleNavigate }: Props) => {
+  return (
+    <div className="flex flex-col gap-4">
+      {wordbooks.map((wordbook) => (
+        <WordbookItem
+          key={wordbook.id}
+          title={wordbook.title}
+          caption={wordbook.caption}
+          handleNavigate={() => handleNavigate(wordbook.id)}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/components/pages/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage.tsx
@@ -12,7 +12,7 @@ const WordbooksPage = () => {
     navigate(`/wordbooks/${id}/wordbook-detail`);
   };
   return (
-    <div className="flex min-h-0 w-full flex-col items-center bg-gray-100">
+    <div className="flex h-full w-full flex-col items-center bg-gray-100">
       <Header title="Wordbooks Page" variant="basic" />
       <main className="mt-[2.25rem] flex min-h-0 w-full flex-1 flex-col items-center px-[1.25rem]">
         <TabSwitcher tabs={tabs} activeTab={activeTab} onChange={setActiveTab} />

--- a/src/components/pages/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage.tsx
@@ -1,15 +1,24 @@
 import Header from '../organisms/Header/Header';
 import TabSwitcher from '../organisms/TabSwitcher';
 import { useState } from 'react';
+import { WordbookList } from '../organisms/WordbookList/WordbookList';
+import { useNavigate } from 'react-router-dom';
 
 const WordbooksPage = () => {
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<number>(1);
 
+  const handleNavigate = (id: number) => {
+    navigate(`/wordbooks/${id}/wordbook-detail`);
+  };
   return (
-    <div className="flex w-full flex-col items-center bg-gray-50">
+    <div className="flex w-full flex-col items-center bg-gray-100">
       <Header title="Wordbooks Page" variant="basic" />
-      <main className="flex w-full flex-col items-center px-5">
+      <main className="mt-[2.25rem] flex w-full flex-col items-center px-[1.25rem]">
         <TabSwitcher tabs={tabs} activeTab={activeTab} onChange={setActiveTab} />
+        <div className="flex-1 overflow-hidden py-[1.25rem]">
+          <WordbookList wordbooks={mockBooks} handleNavigate={() => handleNavigate} />
+        </div>
       </main>
     </div>
   );
@@ -21,4 +30,17 @@ export default WordbooksPage;
 const tabs = [
   { id: 1, label: '커리큘럼' },
   { id: 2, label: '내 단어장' },
+];
+
+const mockBooks = [
+  { id: 1, title: 'Day 1 - Basic Vocabulary', caption: '기초 단어 20개 학습' },
+  { id: 2, title: 'Day 2 - Essential Verbs', caption: '기초 동사 중심 단어장' },
+  { id: 3, title: 'Day 3 - Travel Words', caption: '여행 갈 때 꼭 쓰는 표현 모음' },
+  { id: 4, title: 'Day 4 - Food & Restaurant', caption: '카페/식당에서 자주 쓰는 단어' },
+  { id: 5, title: 'Day 5 - Daily Conversation', caption: '일상 회화 필수 단어' },
+  { id: 6, title: 'Day 6 - Emotion Words', caption: '감정 표현 관련 단어 모음' },
+  { id: 7, title: 'Day 7 - Work & Office', caption: '직장/업무 관련 영어 단어' },
+  { id: 8, title: 'Day 8 - Shopping', caption: '쇼핑 상황에서 쓰는 표현' },
+  { id: 9, title: 'Day 9 - School', caption: '학교 생활 단어 세트' },
+  { id: 10, title: 'Day 10 - Weather & Nature', caption: '날씨/자연 관련 단어장' },
 ];

--- a/src/components/pages/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage.tsx
@@ -3,13 +3,15 @@ import TabSwitcher from '../organisms/TabSwitcher';
 import { useState } from 'react';
 import { WordbookList } from '../organisms/WordbookList/WordbookList';
 import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '../../router/path';
 
 const WordbooksPage = () => {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<number>(1);
 
   const handleNavigate = (id: number) => {
-    navigate(`/wordbooks/${id}/wordbook-detail`);
+    const path = ROUTES.WORDBOOK_DETAIL.replace('wordbookId', String(id));
+    navigate(path);
   };
 
   return (

--- a/src/components/pages/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage.tsx
@@ -16,7 +16,7 @@ const WordbooksPage = () => {
       <Header title="Wordbooks Page" variant="basic" />
       <main className="mt-[2.25rem] flex min-h-0 w-full flex-1 flex-col items-center px-[1.25rem]">
         <TabSwitcher tabs={tabs} activeTab={activeTab} onChange={setActiveTab} />
-        <div className="w-full flex-1 overflow-y-auto py-[1.25rem]">
+        <div className="mt-[1.25rem] mb-[2.25rem] w-full flex-1 overflow-y-auto">
           <WordbookList wordbooks={mockBooks} handleNavigate={handleNavigate} />
         </div>
       </main>

--- a/src/components/pages/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage.tsx
@@ -12,12 +12,12 @@ const WordbooksPage = () => {
     navigate(`/wordbooks/${id}/wordbook-detail`);
   };
   return (
-    <div className="flex w-full flex-col items-center bg-gray-100">
+    <div className="flex min-h-0 w-full flex-col items-center bg-gray-100">
       <Header title="Wordbooks Page" variant="basic" />
-      <main className="mt-[2.25rem] flex w-full flex-col items-center px-[1.25rem]">
+      <main className="mt-[2.25rem] flex min-h-0 w-full flex-1 flex-col items-center px-[1.25rem]">
         <TabSwitcher tabs={tabs} activeTab={activeTab} onChange={setActiveTab} />
-        <div className="flex-1 overflow-hidden py-[1.25rem]">
-          <WordbookList wordbooks={mockBooks} handleNavigate={() => handleNavigate} />
+        <div className="w-full flex-1 overflow-y-auto py-[1.25rem]">
+          <WordbookList wordbooks={mockBooks} handleNavigate={handleNavigate} />
         </div>
       </main>
     </div>

--- a/src/components/pages/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage.tsx
@@ -11,6 +11,7 @@ const WordbooksPage = () => {
   const handleNavigate = (id: number) => {
     navigate(`/wordbooks/${id}/wordbook-detail`);
   };
+
   return (
     <div className="flex h-full w-full flex-col items-center bg-gray-100">
       <Header title="Wordbooks Page" variant="basic" />
@@ -32,6 +33,7 @@ const tabs = [
   { id: 2, label: '내 단어장' },
 ];
 
+// mock data
 const mockBooks = [
   { id: 1, title: 'Day 1 - Basic Vocabulary', caption: '기초 단어 20개 학습' },
   { id: 2, title: 'Day 2 - Essential Verbs', caption: '기초 동사 중심 단어장' },

--- a/src/components/pages/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage.tsx
@@ -1,3 +1,4 @@
+import Header from '../organisms/Header/Header';
 import TabSwitcher from '../organisms/TabSwitcher';
 import { useState } from 'react';
 
@@ -6,7 +7,7 @@ const WordbooksPage = () => {
 
   return (
     <div className="flex w-full flex-col items-center bg-gray-50">
-      <h1>Wordbook Page</h1>
+      <Header title="Wordbooks Page" variant="basic" />
       <main className="flex w-full flex-col items-center px-5">
         <TabSwitcher tabs={tabs} activeTab={activeTab} onChange={setActiveTab} />
       </main>

--- a/src/components/pages/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage.tsx
@@ -1,7 +1,7 @@
 import TabSwitcher from '../organisms/TabSwitcher';
 import { useState } from 'react';
 
-const WordbookPage = () => {
+const WordbooksPage = () => {
   const [activeTab, setActiveTab] = useState<number>(1);
 
   return (
@@ -14,7 +14,7 @@ const WordbookPage = () => {
   );
 };
 
-export default WordbookPage;
+export default WordbooksPage;
 
 // 정적 데이터
 const tabs = [

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -5,7 +5,7 @@ const Layout = () => {
   return (
     <div className="flex justify-center bg-gray-100">
       <div className="flex h-dvh w-dvw flex-col bg-white sm:w-[360px]">
-        <main className="flex min-h-0 flex-1">
+        <main className="flex min-h-0 flex-1 flex-col">
           <Outlet />
         </main>
         <footer>

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -5,7 +5,7 @@ const Layout = () => {
   return (
     <div className="flex justify-center bg-gray-100">
       <div className="flex h-dvh w-dvw flex-col bg-white sm:w-[360px]">
-        <main className="flex flex-1">
+        <main className="flex min-h-0 flex-1">
           <Outlet />
         </main>
         <footer>

--- a/src/router/ProtectedRoutes.tsx
+++ b/src/router/ProtectedRoutes.tsx
@@ -3,21 +3,22 @@ import HomePage from '../components/pages/HomePage';
 import WordbooksPage from '../components/pages/WordbooksPage';
 import Layout from '../layouts/Layout';
 import SettingPage from '../components/pages/SettingPage';
+import { ROUTES } from './path';
 
 export const protectedRoutes: RouteObject[] = [
   {
     element: <Layout />,
     children: [
       {
-        path: '/',
+        path: ROUTES.HOME,
         element: <HomePage />,
       },
       {
-        path: '/wordbooks',
+        path: ROUTES.WORDBOOKS,
         element: <WordbooksPage />,
       },
       {
-        path: '/setting',
+        path: ROUTES.SETTING,
         element: <SettingPage />,
       },
     ],

--- a/src/router/ProtectedRoutes.tsx
+++ b/src/router/ProtectedRoutes.tsx
@@ -1,6 +1,6 @@
 import { type RouteObject } from 'react-router-dom';
 import HomePage from '../components/pages/HomePage';
-import WordbookPage from '../components/pages/WordbookPage';
+import WordbooksPage from '../components/pages/WordbooksPage';
 import Layout from '../layouts/Layout';
 import SettingPage from '../components/pages/SettingPage';
 
@@ -13,8 +13,8 @@ export const protectedRoutes: RouteObject[] = [
         element: <HomePage />,
       },
       {
-        path: '/wordbook',
-        element: <WordbookPage />,
+        path: '/wordbooks',
+        element: <WordbooksPage />,
       },
       {
         path: '/setting',

--- a/src/router/path.ts
+++ b/src/router/path.ts
@@ -1,0 +1,9 @@
+/*
+    Route path 의 실제 문자열 값을 선언하는 유일한 위치
+ */
+
+export const ROUTES = {
+  HOME: '/',
+  WORDBOOKS: '/wordbooks',
+  SETTING: '/setting',
+};

--- a/src/router/path.ts
+++ b/src/router/path.ts
@@ -5,5 +5,6 @@
 export const ROUTES = {
   HOME: '/',
   WORDBOOKS: '/wordbooks',
+  WORDBOOK_DETAIL: '/wordbook/wordbookId/wordbook-detail',
   SETTING: '/setting',
 };


### PR DESCRIPTION
## 🫧 요약

- 단어장 목록 페이지 UI 작업

## ✅ 작업 내용

- [x] WordbookItem.tsx - 컴포넌트 개발
- [x] WordbookList.tsx - 컴포넌트 개발
- [x] WordbooksPage.tsx - 조립 & 목데이터 주입
- [x] router - 라우팅 경로 상수화

## 🧪 테스트 방법

- 스토리북 참고

## 📷 참고 자료 - 스크린샷 / 링크 / GIF / ...
<img width="449" height="866" alt="image" src="https://github.com/user-attachments/assets/94d358b0-a7a5-4af1-9240-a3efc50b6b44" />

## ❣️ 관련 이슈

- close #18 #8 

## ☝️ 참고 사항

- layout 살짝 건드렸습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 단어장 목록 페이지 및 항목 컴포넌트 추가 — 항목 선택 시 상세로 이동 가능

* **UI/UX 개선**
  * 항목의 네비게이션 버튼(아이콘 색상 포함) 및 레이아웃/간격 조정(탭 스위처 높이·패딩·간격)
  * 메인 레이아웃 CSS 개선

* **리팩토링**
  * 라우트 경로를 중앙 ROUTES 상수로 통합 및 네비게이션 비교 지점 적용

* **문서(Storybook)**
  * WordbookItem 및 WordbookList 스토리 추가

* **제거**
  * 기존 WordbookPage 컴포넌트 삭제

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->