### PR TITLE
[FEAT] 회원 정보 섹션 컴포넌트 제작

### DIFF
--- a/src/components/organisms/UserProfileCard/UserProfileCard.stories.tsx
+++ b/src/components/organisms/UserProfileCard/UserProfileCard.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { UserProfileCard } from './UserProfileCard';
+
+const meta: Meta<typeof UserProfileCard> = {
+  title: 'Components/UserProfileCard',
+  component: UserProfileCard,
+  tags: ['autodocs'],
+  args: {
+    name: '홍길동',
+    email: 'hong@example.com',
+    profileImage:
+      'https://images.unsplash.com/photo-1607746882042-944635dfe10e?w=200&h=200&fit=crop',
+  },
+  argTypes: {
+    profileImage: { control: 'text' },
+    name: { control: 'text' },
+    email: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof UserProfileCard>;
+
+export const Default: Story = {};
+
+export const NoImage: Story = {
+  args: {
+    profileImage: null,
+  },
+};

--- a/src/components/organisms/UserProfileCard/UserProfileCard.stories.tsx
+++ b/src/components/organisms/UserProfileCard/UserProfileCard.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { UserProfileCard } from './UserProfileCard';
 
 const meta: Meta<typeof UserProfileCard> = {
-  title: 'Components/UserProfileCard',
+  title: 'Organisms/UserProfileCard',
   component: UserProfileCard,
   tags: ['autodocs'],
   args: {

--- a/src/components/organisms/UserProfileCard/UserProfileCard.tsx
+++ b/src/components/organisms/UserProfileCard/UserProfileCard.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export const UserProfileCard = ({ profileImage, name, email }: Props) => {
   return (
-    <section className="flex py-[1.25rem] pr-[3.62rem] pl-[1.75rem]">
+    <section className="flex px-[1.75rem] py-[1.25rem]">
       <div className="flex items-center gap-[1.75rem]">
         <div className="h-[4.5rem] w-[4.5rem] overflow-hidden rounded-full">
           {profileImage ? (

--- a/src/components/organisms/UserProfileCard/UserProfileCard.tsx
+++ b/src/components/organisms/UserProfileCard/UserProfileCard.tsx
@@ -1,0 +1,25 @@
+type Props = {
+  profileImage: string | null;
+  name: string;
+  email: string;
+};
+
+export const UserProfileCard = ({ profileImage, name, email }: Props) => {
+  return (
+    <section className="flex py-[1.25rem] pr-[3.62rem] pl-[1.75rem]">
+      <div className="flex items-center gap-[1.75rem]">
+        <div className="h-[4.5rem] w-[4.5rem] overflow-hidden rounded-full">
+          {profileImage ? (
+            <img src={profileImage} alt="프로필 이미지" className="h-full w-full object-cover" />
+          ) : (
+            <div className="h-full w-full bg-gray-200" />
+          )}
+        </div>
+        <div className="flex flex-col gap-[0.25rem]">
+          <h2 className="text-xl font-semibold">{name}님</h2>
+          <p className="text-gray-400">{email}</p>
+        </div>
+      </div>
+    </section>
+  );
+};


### PR DESCRIPTION
## 🫧 요약

- 회원 정보 섹션 컴포넌트 제작

## ✅ 작업 내용

- [x] 컴포넌트 이름 : UserProfileCard 로 해봤습니다
- [x] 계층 : Organisms

## 🧪 테스트 방법

- 스토리북 실행 후 Organisms/UserProfileCard 컴포넌트 확인

## 📷 참고 자료 - 스크린샷 / 링크 / GIF / ...
<img width="474" height="138" alt="image" src="https://github.com/user-attachments/assets/e5e81f00-e559-4559-b0ce-095145ebf48c" />


## ❣️ 관련 이슈

- close #24

## ☝️ 참고 사항

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 프로필 카드 컴포넌트가 추가되었습니다. 프로필 이미지, 이름(님 접미사) 및 이메일을 표시하며, 이미지가 없을 때 회색 플레이스홀더를 지원합니다.
* **문서**
  * 컴포넌트용 스토리북 항목이 추가되었습니다. 기본 보기와 이미지 없는(NoImage) 변형을 통해 컴포넌트 상태를 미리볼 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->