### PR TITLE
[FEAT] 설정 버튼 및 설정 리스트 컴포넌트 제작

### DIFF
--- a/src/components/molecules/SettingItem/SettingItem.stories.tsx
+++ b/src/components/molecules/SettingItem/SettingItem.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { SettingItem } from './SettingItem';
+
+const meta: Meta<typeof SettingItem> = {
+  title: 'Molecules/SettingItem',
+  component: SettingItem,
+  tags: ['autodocs'],
+  args: {
+    label: '로그아웃',
+    handleNavigate: () => alert('clicked!'),
+  },
+  argTypes: {
+    label: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SettingItem>;
+
+export const Default: Story = {};
+
+export const Withdraw: Story = {
+  args: {
+    label: '회원탈퇴',
+  },
+};

--- a/src/components/molecules/SettingItem/SettingItem.tsx
+++ b/src/components/molecules/SettingItem/SettingItem.tsx
@@ -9,7 +9,7 @@ export const SettingItem = ({ label, handleNavigate }: SettingItemProps) => {
   return (
     <div className="flex w-full justify-between">
       {label}
-      <button onClick={handleNavigate}>
+      <button onClick={handleNavigate} className="flex items-center">
         <Icon name="ChevronRight" size={20} />
       </button>
     </div>

--- a/src/components/molecules/SettingItem/SettingItem.tsx
+++ b/src/components/molecules/SettingItem/SettingItem.tsx
@@ -1,0 +1,17 @@
+import { Icon } from '../../atoms/Icon/Icon';
+
+export type SettingItemProps = {
+  label: string;
+  handleNavigate: () => void;
+};
+
+export const SettingItem = ({ label, handleNavigate }: SettingItemProps) => {
+  return (
+    <div className="flex w-full justify-between">
+      {label}
+      <button onClick={handleNavigate}>
+        <Icon name="ChevronRight" size={20} />
+      </button>
+    </div>
+  );
+};

--- a/src/components/organisms/SettingList/SettingList.stories.tsx
+++ b/src/components/organisms/SettingList/SettingList.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { SettingList } from './SettingList';
+
+const meta: Meta<typeof SettingList> = {
+  title: 'Organisms/SettingList',
+  component: SettingList,
+  tags: ['autodocs'],
+  args: {
+    items: [
+      {
+        label: '로그아웃',
+        handleNavigate: () => alert('로그아웃 클릭됨!'),
+      },
+      {
+        label: '회원탈퇴',
+        handleNavigate: () => alert('회원탈퇴 클릭됨!'),
+      },
+      {
+        label: '알림 설정',
+        handleNavigate: () => alert('알림 설정 클릭됨!'),
+      },
+    ],
+  },
+  argTypes: {
+    items: { control: false }, // 배열 컨트롤 비활성화 (불필요해서)
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SettingList>;
+
+export const Default: Story = {};
+
+export const TwoItems: Story = {
+  args: {
+    items: [
+      { label: '로그아웃', handleNavigate: () => alert('로그아웃 클릭됨!') },
+      { label: '회원탈퇴', handleNavigate: () => alert('회원탈퇴 클릭됨!') },
+    ],
+  },
+};
+
+export const SingleItem: Story = {
+  args: {
+    items: [{ label: '알림 설정', handleNavigate: () => alert('알림 설정 클릭됨!') }],
+  },
+};

--- a/src/components/organisms/SettingList/SettingList.tsx
+++ b/src/components/organisms/SettingList/SettingList.tsx
@@ -1,0 +1,16 @@
+import { SettingItem } from '../../molecules/SettingItem/SettingItem';
+import { type SettingItemProps } from '../../molecules/SettingItem/SettingItem';
+
+type Props = {
+  items: SettingItemProps[];
+};
+
+export const SettingList = ({ items }: Props) => {
+  return (
+    <div className="flex flex-col gap-[1.25rem] p-[1.5rem]">
+      {items.map((item, idx) => (
+        <SettingItem key={idx} label={item.label} handleNavigate={item.handleNavigate} />
+      ))}
+    </div>
+  );
+};


### PR DESCRIPTION
## 🫧 요약

- 설정 버튼 및 설정 리스트 컴포넌트 제작

## ✅ 작업 내용

- [x] 이름 : 아이템과 매핑하는 리스트 의미를 넣는게 좋을 것 같아서 각각 SettingItem, SettingList 으로 제작했습니다
- [x] 계층 : 각각 molecule/organisms

## 🧪 테스트 방법

- pnpm storybook 후 molecule/SettingItem, organisms/SettingList 확인
- 스토리북 버튼 이벤트는 알럿입니다

## 📷 참고 자료 - 스크린샷 / 링크 / GIF / ...
<img width="545" height="195" alt="image" src="https://github.com/user-attachments/assets/111750d0-6999-40e0-87e9-fce4ec4663a8" />


## ❣️ 관련 이슈

- close #25

## ☝️ 참고 사항

- 리뷰에 type="button" 명시하라고 하는데, 적용하는게 좋을까요? 적용하게 되면 다른 버튼 컴포넌트들에도 일괄 적용 해야할 것 같아서요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 설정 항목 컴포넌트 추가: 라벨과 네비게이션 버튼(우측 화살표)을 제공하여 클릭 시 이동 동작을 트리거합니다.
  * 설정 목록 컴포넌트 추가: 여러 설정 항목을 세로 리스트로 표시하고 각 항목의 이동 동작을 연결합니다.

* **테스트**
  * 각 컴포넌트용 Storybook 스토리 추가(다양한 항목 구성 및 라벨 케이스 포함).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->