### PR TITLE
[FEAT] 마이 페이지 UI 개발

### DIFF
--- a/src/components/organisms/SettingList/SettingList.tsx
+++ b/src/components/organisms/SettingList/SettingList.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export const SettingList = ({ items }: Props) => {
   return (
-    <div className="flex flex-col gap-[1.25rem] p-[1.5rem]">
+    <div className="flex w-full flex-col gap-[1.25rem] bg-white p-[1.5rem]">
       {items.map((item, idx) => (
         <SettingItem key={idx} label={item.label} handleNavigate={item.handleNavigate} />
       ))}

--- a/src/components/organisms/UserProfileCard/UserProfileCard.tsx
+++ b/src/components/organisms/UserProfileCard/UserProfileCard.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export const UserProfileCard = ({ profileImage, name, email }: Props) => {
   return (
-    <section className="flex px-[1.75rem] py-[1.25rem]">
+    <section className="flex w-full bg-white px-[1.75rem] py-[1.25rem]">
       <div className="flex items-center gap-[1.75rem]">
         <div className="h-[4.5rem] w-[4.5rem] overflow-hidden rounded-full">
           {profileImage ? (

--- a/src/components/pages/SettingPage.tsx
+++ b/src/components/pages/SettingPage.tsx
@@ -1,4 +1,42 @@
+import Header from '../organisms/Header/Header';
+import { SettingList } from '../organisms/SettingList/SettingList';
+import { UserProfileCard } from '../organisms/UserProfileCard/UserProfileCard';
+
 const SettingPage = () => {
-  return <div>Setting Page</div>;
+  const handleLogout = () => {
+    console.log('[미구현] 로그아웃 액션');
+  };
+
+  const handleAccountDeletion = () => {
+    console.log('[미구현] 회원탈퇴 액션');
+  };
+
+  return (
+    <div className="flex h-full w-full flex-col items-center bg-gray-100">
+      <Header title="Setting Page" />
+      <div className="h-[0.75rem] w-full"></div>
+      <UserProfileCard
+        profileImage={profileData.profileImage}
+        email={profileData.email}
+        name={profileData.name}
+      />
+      <div className="h-[0.5rem] w-full"></div>
+      <SettingList
+        items={[
+          { label: '로그아웃', handleNavigate: handleLogout },
+          { label: '회원탈퇴', handleNavigate: handleAccountDeletion },
+        ]}
+      />
+    </div>
+  );
 };
+
 export default SettingPage;
+
+// mock data
+
+const profileData = {
+  profileImage: '',
+  email: 'hong@example.com',
+  name: '박진주',
+};


### PR DESCRIPTION
## 🫧 요약

- 마이 페이지 UI 개발

## ✅ 작업 내용

- [x] UI 조립
- [x] 컴포넌트 배경색 + width 속성 수정

## 🧪 테스트 방법

## 📷 참고 자료 - 스크린샷 / 링크 / GIF / ...
<img width="358" height="918" alt="image" src="https://github.com/user-attachments/assets/3951ccbc-46b7-4520-91a6-52e7caa869e3" />

## ❣️ 관련 이슈

- close #23 

## ☝️ 참고 사항

- 하위 컴포넌트 상단에 w-full, bg-white 추가했습니다.
- handleNavigate 은 일단 미구현 액션으로 넘겨주고 있어요. 나중에 모달을 띄울 지 페이지 라우팅을 할 지 논의해 봅시다!
- 마이페이지와 Setting Page 용어가 서로 안 맞는 것 같아서 한 가지로 확정하는 게 좋을 것 같아요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 설정 페이지에 사용자 프로필 카드 추가
  * 로그아웃 및 회원탈퇴 옵션 구현

* **Style**
  * 설정 및 프로필 관련 UI 컴포넌트에 배경색과 전체 너비 적용
  * 컴포넌트 시각적 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->