### PR TITLE
[FEAT] 사용자 프로필 정보 API 연동

### DIFF
--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -1,0 +1,13 @@
+import type { Profile } from '../../domain/user';
+import { mapUserProfileResponseToDomain } from '../../mapper/user';
+import { api } from '../axiosInstance';
+
+export const getUserProfileData = async (): Promise<Profile> => {
+  try {
+    const res = await api.get('user/profile');
+    return mapUserProfileResponseToDomain(res.data);
+  } catch (error) {
+    console.error('[ERROR] 사용자 프로필 정보 조회 실패: ', error);
+    throw error;
+  }
+};

--- a/src/apis/user/types.ts
+++ b/src/apis/user/types.ts
@@ -1,0 +1,5 @@
+export type GetUserProfileDataResponse = {
+  email: string;
+  name: string;
+  profile_image_url: string;
+};

--- a/src/components/pages/SettingPage.tsx
+++ b/src/components/pages/SettingPage.tsx
@@ -1,9 +1,14 @@
+import { useEffect, useState } from 'react';
 import supabase from '../../apis/supabase';
 import Header from '../organisms/Header/Header';
 import { SettingList } from '../organisms/SettingList/SettingList';
 import { UserProfileCard } from '../organisms/UserProfileCard/UserProfileCard';
+import { getUserProfileData } from '../../apis/user';
+import type { Profile } from '../../domain/user';
 
 const SettingPage = () => {
+  const [profile, setProfile] = useState<Profile | null>(null);
+
   const handleLogout = async () => {
     const { error } = await supabase.auth.signOut();
     console.log(error);
@@ -13,14 +18,30 @@ const SettingPage = () => {
     console.log('[미구현] 회원탈퇴 액션');
   };
 
+  useEffect(() => {
+    const fetchProfileData = async () => {
+      try {
+        const data = await getUserProfileData();
+        setProfile(data);
+      } catch (_) {
+        // TODO : 에러 발생 시 UI/UX 기획 필요
+        alert('사용자 프로필 정보를 불러오는 데에 실패했습니다. 다시 시도해주세요.');
+      }
+    };
+    fetchProfileData();
+  }, []);
+
+  // TODO : 로딩 스피너 같은 거 필요할 듯
+  if (!profile) return null;
+
   return (
     <div className="flex h-full w-full flex-col items-center bg-gray-100">
       <Header title="Setting Page" />
       <div className="h-[0.75rem] w-full"></div>
       <UserProfileCard
-        profileImage={profileData.profileImage}
-        email={profileData.email}
-        name={profileData.name}
+        profileImage={profile.profile_image_url}
+        email={profile.email}
+        name={profile.name}
       />
       <div className="h-[0.5rem] w-full"></div>
       <SettingList
@@ -34,11 +55,3 @@ const SettingPage = () => {
 };
 
 export default SettingPage;
-
-// mock data
-
-const profileData = {
-  profileImage: '',
-  email: 'hong@example.com',
-  name: '박진주',
-};

--- a/src/components/pages/SettingPage.tsx
+++ b/src/components/pages/SettingPage.tsx
@@ -39,7 +39,7 @@ const SettingPage = () => {
     case 'loading':
       return <div>Loading...</div>;
     case 'error':
-      return <div>Error occurred while fetching words.</div>;
+      return <div>오류가 발생했습니다. 다시 시도해주세요.</div>;
   }
 
   return (

--- a/src/components/pages/SettingPage.tsx
+++ b/src/components/pages/SettingPage.tsx
@@ -5,9 +5,10 @@ import { SettingList } from '../organisms/SettingList/SettingList';
 import { UserProfileCard } from '../organisms/UserProfileCard/UserProfileCard';
 import { getUserProfileData } from '../../apis/user';
 import type { Profile } from '../../domain/user';
+import type { AsyncState } from '../../shared/types/asyncState';
 
 const SettingPage = () => {
-  const [profile, setProfile] = useState<Profile | null>(null);
+  const [profile, setProfile] = useState<AsyncState<Profile>>({ status: 'idle' });
 
   const handleLogout = async () => {
     const { error } = await supabase.auth.signOut();
@@ -21,27 +22,34 @@ const SettingPage = () => {
   useEffect(() => {
     const fetchProfileData = async () => {
       try {
+        setProfile({ status: 'loading' });
         const data = await getUserProfileData();
-        setProfile(data);
+        setProfile({ status: 'success', data: data });
       } catch (_) {
         // TODO : 에러 발생 시 UI/UX 기획 필요
+        setProfile({ status: 'error' });
         alert('사용자 프로필 정보를 불러오는 데에 실패했습니다. 다시 시도해주세요.');
       }
     };
     fetchProfileData();
   }, []);
 
-  // TODO : 로딩 스피너 같은 거 필요할 듯
-  if (!profile) return null;
+  switch (profile.status) {
+    case 'idle':
+    case 'loading':
+      return <div>Loading...</div>;
+    case 'error':
+      return <div>Error occurred while fetching words.</div>;
+  }
 
   return (
     <div className="flex h-full w-full flex-col items-center bg-gray-100">
       <Header title="Setting Page" />
       <div className="h-[0.75rem] w-full"></div>
       <UserProfileCard
-        profileImage={profile.profile_image_url}
-        email={profile.email}
-        name={profile.name}
+        profileImage={profile.data.profile_image_url}
+        email={profile.data.email}
+        name={profile.data.name}
       />
       <div className="h-[0.5rem] w-full"></div>
       <SettingList

--- a/src/components/pages/WordbookDetailPage.tsx
+++ b/src/components/pages/WordbookDetailPage.tsx
@@ -41,7 +41,7 @@ export const WordbookDetailPage = () => {
     case 'loading':
       return <div>Loading...</div>;
     case 'error':
-      return <div>Error occurred while fetching words.</div>;
+      return <div>오류가 발생했습니다. 다시 시도해주세요.</div>;
   }
 
   return (

--- a/src/components/pages/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage.tsx
@@ -38,7 +38,7 @@ const WordbooksPage = () => {
     case 'loading':
       return <div>Loading...</div>;
     case 'error':
-      return <div>Error occurred while fetching words.</div>;
+      return <div>오류가 발생했습니다. 다시 시도해주세요.</div>;
   }
 
   return (

--- a/src/components/pages/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage.tsx
@@ -6,11 +6,12 @@ import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '../../router/path';
 import { getWordbookList } from '../../apis/wordbook';
 import type { Wordbook } from '../../domain/wordbook';
+import type { AsyncState } from '../../shared/types/asyncState';
 
 const WordbooksPage = () => {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<number>(1);
-  const [wordbooks, setWordbooks] = useState<Wordbook[]>([]); // TODO : Api 응답 전용 타입 말고 클라이언트 전용 타입으로 교체
+  const [wordbooks, setWordbooks] = useState<AsyncState<Wordbook[]>>({ status: 'idle' });
 
   const handleNavigate = (id: string) => {
     const path = ROUTES.WORDBOOK_DETAIL.replace(':wordbookId', String(id));
@@ -20,16 +21,25 @@ const WordbooksPage = () => {
   useEffect(() => {
     async function fetchWordbookList() {
       try {
+        setWordbooks({ status: 'loading' });
         const data = await getWordbookList();
-        setWordbooks(data);
+        setWordbooks({ status: 'success', data: data });
       } catch (_) {
         // TODO : 에러 발생 시 UI/UX 기획 필요
+        setWordbooks({ status: 'error' });
         alert('단어장 목록을 불러오는 데에 실패했습니다. 다시 시도해주세요.');
-        // setError(true);
       }
     }
     fetchWordbookList();
   }, []);
+
+  switch (wordbooks.status) {
+    case 'idle':
+    case 'loading':
+      return <div>Loading...</div>;
+    case 'error':
+      return <div>Error occurred while fetching words.</div>;
+  }
 
   return (
     <div className="flex h-full w-full flex-col items-center bg-gray-100">
@@ -37,7 +47,7 @@ const WordbooksPage = () => {
       <main className="mt-[2.25rem] flex min-h-0 w-full flex-1 flex-col items-center px-[1.25rem]">
         <TabSwitcher tabs={tabs} activeTab={activeTab} onChange={setActiveTab} />
         <div className="mt-[1.25rem] mb-[2.25rem] w-full flex-1 overflow-y-auto">
-          <WordbookList wordbooks={wordbooks} handleNavigate={handleNavigate} />
+          <WordbookList wordbooks={wordbooks.data} handleNavigate={handleNavigate} />
         </div>
       </main>
     </div>
@@ -51,17 +61,3 @@ const tabs = [
   { id: 1, label: '커리큘럼' },
   { id: 2, label: '내 단어장' },
 ];
-
-// mock data
-// const mockBooks = [
-//   { id: 1, title: 'Day 1 - Basic Vocabulary', caption: '기초 단어 20개 학습' },
-//   { id: 2, title: 'Day 2 - Essential Verbs', caption: '기초 동사 중심 단어장' },
-//   { id: 3, title: 'Day 3 - Travel Words', caption: '여행 갈 때 꼭 쓰는 표현 모음' },
-//   { id: 4, title: 'Day 4 - Food & Restaurant', caption: '카페/식당에서 자주 쓰는 단어' },
-//   { id: 5, title: 'Day 5 - Daily Conversation', caption: '일상 회화 필수 단어' },
-//   { id: 6, title: 'Day 6 - Emotion Words', caption: '감정 표현 관련 단어 모음' },
-//   { id: 7, title: 'Day 7 - Work & Office', caption: '직장/업무 관련 영어 단어' },
-//   { id: 8, title: 'Day 8 - Shopping', caption: '쇼핑 상황에서 쓰는 표현' },
-//   { id: 9, title: 'Day 9 - School', caption: '학교 생활 단어 세트' },
-//   { id: 10, title: 'Day 10 - Weather & Nature', caption: '날씨/자연 관련 단어장' },
-// ];

--- a/src/domain/user.ts
+++ b/src/domain/user.ts
@@ -1,0 +1,5 @@
+export type Profile = {
+  email: string;
+  name: string;
+  profile_image_url: string;
+};

--- a/src/mapper/user.ts
+++ b/src/mapper/user.ts
@@ -1,0 +1,10 @@
+import type { GetUserProfileDataResponse } from '../apis/user/types';
+import type { Profile } from '../domain/user';
+
+export const mapUserProfileResponseToDomain = (response: GetUserProfileDataResponse): Profile => {
+  return {
+    email: response.email,
+    name: response.name,
+    profile_image_url: response.profile_image_url,
+  };
+};


### PR DESCRIPTION
## 🫧 요약

- 사용자 프로필 정보 API 연동

## ✅ 작업 내용

- [x] API 연동

## 🧪 테스트 방법

- Setting page 탭 접속

## 📷 참고 자료 - 스크린샷 / 링크 / GIF / ...
<img width="359" height="316" alt="image" src="https://github.com/user-attachments/assets/e57987b0-9e50-4289-8fbc-6fff6cdfab1e" />

## ❣️ 관련 이슈

- close #35 

## ☝️ 참고 사항

- mapper 함수 이름 관련 규칙 정립 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 설정 페이지가 서버에서 사용자 프로필(이메일, 이름, 프로필 사진)을 실제로 불러와 표시합니다.
  * API 응답을 앱 도메인 형식으로 변환하는 일관된 매핑이 추가되어 프로필 데이터가 안정적으로 사용됩니다.
  * 단어장 페이지가 비동기 상태(idle/loading/success/error)를 반영해 실제 데이터로 렌더링됩니다.

* **버그 수정 / 개선**
  * 로딩 및 오류 상태 처리와 사용자 알림이 향상되었습니다.
  * 단어장 상세의 오류 메시지가 한국어로 변경되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->