### PR TITLE
[FIX] 홈페이지 접근 제한

### DIFF
--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -1,14 +1,10 @@
-import Header from '../organisms/Header/Header';
+import { Navigate } from 'react-router-dom';
+import { ROUTES } from '../../router/path';
 
 const HomePage = () => {
-  return (
-    <div className="flex w-full flex-1 flex-col">
-      <header>
-        <Header title="Seri Voca" variant="basic" />
-      </header>
-      <h1>Home Page</h1>
-    </div>
-  );
+  // home page 미구현
+  // 구현 전까지는 wordbooks page 로 redirect
+  return <Navigate to={ROUTES.WORDBOOKS} replace />;
 };
 
 export default HomePage;

--- a/src/components/pages/LoginPage.tsx
+++ b/src/components/pages/LoginPage.tsx
@@ -14,7 +14,7 @@ const LoginPage = () => {
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'kakao',
       options: {
-        redirectTo: BASE_URL + ROUTES.WORDBOOKS,
+        redirectTo: BASE_URL + ROUTES.HOME,
       },
     });
     if (error) {

--- a/src/components/pages/SettingPage.tsx
+++ b/src/components/pages/SettingPage.tsx
@@ -55,7 +55,8 @@ const SettingPage = () => {
       <SettingList
         items={[
           { label: '로그아웃', handleNavigate: handleLogout },
-          { label: '회원탈퇴', handleNavigate: handleAccountDeletion },
+          // TODO : 회원 탈퇴 API 개발 시 복구
+          // { label: '회원탈퇴', handleNavigate: handleAccountDeletion },
         ]}
       />
     </div>


### PR DESCRIPTION
## 🫧 요약

- 홈페이지 접근 제한 및 회원 탈퇴 구현

## ✅ 작업 내용

- [x] 홈페이지 접근 제한
- [x] 회원 탈퇴 UI 일시적으로 숨김

## 🧪 테스트 방법

- 로그인/비로그인으로 base url 접근 시도

## 📷 참고 자료 - 스크린샷 / 링크 / GIF / ...

## ❣️ 관련 이슈

- close #43 

## ☝️ 참고 사항

- 참고하세요~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경사항**
  * 홈페이지를 단어장 페이지로 자동 리다이렉트하도록 변경
  * Kakao 로그인 후 리다이렉트 경로를 단어장 페이지에서 홈페이지로 변경
  * 설정 메뉴에서 계정 삭제 옵션 제거

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->