### PR TITLE
[FIX] 나의 단어장 탭 진입 막기

### DIFF
--- a/src/components/molecules/TabItem.tsx
+++ b/src/components/molecules/TabItem.tsx
@@ -1,6 +1,7 @@
 type Props = {
   label: string;
   active: boolean;
+  disabled?: boolean;
   onClick: () => void;
 };
 

--- a/src/components/molecules/TabItem.tsx
+++ b/src/components/molecules/TabItem.tsx
@@ -1,7 +1,6 @@
 type Props = {
   label: string;
   active: boolean;
-  disabled?: boolean;
   onClick: () => void;
 };
 

--- a/src/components/organisms/TabSwitcher.tsx
+++ b/src/components/organisms/TabSwitcher.tsx
@@ -4,26 +4,28 @@
 
 import TabItem from '../molecules/TabItem';
 
-type Tab = {
+export type Tab = {
   id: number;
   label: string;
+  disabled?: boolean;
 };
 
 type Props = {
   tabs: Tab[];
   activeTab: number;
-  onChange: (tabId: number) => void;
+  onChange: (tab: Tab) => void;
 };
 
 const TabSwitcher = ({ tabs, activeTab, onChange }: Props) => {
   return (
-    <div className="flex h-[2.5rem] w-full items-center justify-center gap-[0.75rem] rounded-full bg-white px-[0.75rem] py-[o.375rem]">
+    <div className="flex h-[2.5rem] w-full items-center justify-center gap-[0.75rem] rounded-full bg-white px-[0.75rem] py-[0.375rem]">
       {tabs.map((tab, index) => (
         <TabItem
           key={index}
           label={tab.label}
           active={tab.id === activeTab}
-          onClick={() => onChange(tab.id)}
+          disabled={tab.disabled}
+          onClick={() => onChange(tab)}
         />
       ))}
     </div>

--- a/src/components/organisms/TabSwitcher.tsx
+++ b/src/components/organisms/TabSwitcher.tsx
@@ -24,7 +24,6 @@ const TabSwitcher = ({ tabs, activeTab, onChange }: Props) => {
           key={index}
           label={tab.label}
           active={tab.id === activeTab}
-          disabled={tab.disabled}
           onClick={() => onChange(tab)}
         />
       ))}

--- a/src/components/pages/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage.tsx
@@ -1,5 +1,5 @@
 import Header from '../organisms/Header/Header';
-import TabSwitcher from '../organisms/TabSwitcher';
+import TabSwitcher, { type Tab } from '../organisms/TabSwitcher';
 import { useEffect, useState } from 'react';
 import { WordbookList } from '../organisms/WordbookList/WordbookList';
 import { useNavigate } from 'react-router-dom';
@@ -33,6 +33,14 @@ const WordbooksPage = () => {
     fetchWordbookList();
   }, []);
 
+  const handleTabClick = (tab: Tab) => {
+    if (tab.disabled) {
+      alert('서비스 준비중입니다.');
+    } else if (tab.disabled == false) {
+      setActiveTab(tab.id);
+    }
+  };
+
   switch (wordbooks.status) {
     case 'idle':
     case 'loading':
@@ -45,7 +53,7 @@ const WordbooksPage = () => {
     <div className="flex h-full w-full flex-col items-center bg-gray-100">
       <Header title="Wordbooks Page" variant="basic" />
       <main className="mt-[2.25rem] flex min-h-0 w-full flex-1 flex-col items-center px-[1.25rem]">
-        <TabSwitcher tabs={tabs} activeTab={activeTab} onChange={setActiveTab} />
+        <TabSwitcher tabs={tabs} activeTab={activeTab} onChange={handleTabClick} />
         <div className="mt-[1.25rem] mb-[2.25rem] w-full flex-1 overflow-y-auto">
           <WordbookList wordbooks={wordbooks.data} handleNavigate={handleNavigate} />
         </div>
@@ -57,7 +65,7 @@ const WordbooksPage = () => {
 export default WordbooksPage;
 
 // 정적 데이터
-const tabs = [
+const tabs: Tab[] = [
   { id: 1, label: '커리큘럼' },
-  { id: 2, label: '내 단어장' },
+  { id: 2, label: '내 단어장', disabled: true },
 ];

--- a/src/components/pages/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage.tsx
@@ -36,7 +36,7 @@ const WordbooksPage = () => {
   const handleTabClick = (tab: Tab) => {
     if (tab.disabled) {
       alert('서비스 준비중입니다.');
-    } else if (tab.disabled == false) {
+    } else if (tab.disabled === false) {
       setActiveTab(tab.id);
     }
   };


### PR DESCRIPTION
## 🫧 요약

- 나의 단어장 탭 진입 막기

## ✅ 작업 내용

- Tab에 disabled 속성 추가
- 페이지에서 Tab disabled 여부에 따라 실행될 콜백 함수 결정하는 핸들러 제작

## ❣️ 관련 이슈

- close #42


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 탭 비활성화 기능 추가
  * "내 단어장" 탭 비활성화
  * 탭 클릭 시 비활성화된 탭에 대한 안내 메시지 표시

* **버그 수정**
  * 탭 컨테이너 패딩 값 수정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->