### PR TITLE
[FEAT] 단어장 생성 모달 추가

### DIFF
--- a/src/components/atoms/Input/Input.stories.tsx
+++ b/src/components/atoms/Input/Input.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Input } from './Input';
+
+const meta: Meta<typeof Input> = {
+  title: 'Atoms/Input',
+  component: Input,
+  tags: ['autodocs'],
+  argTypes: {
+    placeholder: {
+      control: 'text',
+      description: 'Input placeholder text',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {
+  args: {
+    placeholder: '입력하세요',
+  },
+};
+
+export const EmptyPlaceholder: Story = {
+  args: {
+    placeholder: '',
+  },
+};

--- a/src/components/atoms/Input/Input.tsx
+++ b/src/components/atoms/Input/Input.tsx
@@ -1,0 +1,37 @@
+import { forwardRef } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+export interface InputProps {
+  value?: string;
+  defaultValue?: string;
+  placeholder?: string;
+  type?: 'text' | 'password' | 'email' | 'number';
+  disabled?: boolean;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  className?: string;
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    { value, defaultValue, placeholder, type = 'text', disabled = false, onChange, className },
+    ref,
+  ) => {
+    return (
+      <input
+        ref={ref}
+        type={type}
+        value={value}
+        defaultValue={defaultValue}
+        placeholder={placeholder}
+        disabled={disabled}
+        onChange={onChange}
+        className={twMerge(
+          'h-[2.25rem] w-full rounded-md bg-[#e9e9e9] px-2 text-sm focus:outline-none disabled:opacity-50',
+          className,
+        )}
+      />
+    );
+  },
+);
+
+Input.displayName = 'Input';

--- a/src/components/organisms/CreateWordbookModal/CreateWordbookModal.tsx
+++ b/src/components/organisms/CreateWordbookModal/CreateWordbookModal.tsx
@@ -1,0 +1,22 @@
+import { Button } from '@/components/atoms/Button/Button';
+import { Input } from '@/components/atoms/Input/Input';
+
+export interface Props {
+  value: string;
+  onChange: (v: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+}
+
+export const CreateWordbookModal = ({ value, onChange, onSubmit, onCancel }: Props) => {
+  return (
+    <div className="flex flex-col gap-[0.5rem]">
+      <h2 className="text-lg">단어장 이름을 정해주세요</h2>
+      <Input value={value} onChange={(e) => onChange(e.target.value)} />
+      <div className="flex justify-center gap-[0.5rem]">
+        <Button content="생성" variant="primary" onClick={onSubmit} />
+        <Button content="취소" variant="secondary" onClick={onCancel} />
+      </div>
+    </div>
+  );
+};

--- a/src/components/pages/WordbooksPage/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage/WordbooksPage.tsx
@@ -53,11 +53,17 @@ export const WordbooksPage = () => {
         value={wordbookName}
         onChange={setWordbookName}
         onSubmit={() => {
+          if (wordbookName.trim() === '') {
+            alert('단어장 이름을 입력해주세요.');
+            return;
+          }
           // TODO: 단어장 생성 API 연동 및 라우팅 로직 추가
           alert(`단어장 "${wordbookName}"이(가) 생성되었습니다!`);
+          setWordbookName('');
           close('wordbook-create-modal');
         }}
         onCancel={() => {
+          setWordbookName('');
           close('wordbook-create-modal');
         }}
       />

--- a/src/components/pages/WordbooksPage/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage/WordbooksPage.tsx
@@ -6,11 +6,18 @@ import { getWordbookList } from '@/apis/wordbook';
 import type { Wordbook } from '@/domain/wordbook';
 import type { AsyncState } from '@/shared/types/asyncState';
 import { WordbooksPageTemplate } from '@/components/templates/WordbooksPageTemplate/WordbooksPageTemplate';
+import { useModalStore } from '@/store/useModalStore';
+import { CreateWordbookModal } from '@/components/organisms/CreateWordbookModal/CreateWordbookModal';
 
 export const WordbooksPage = () => {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<number>(1);
   const [wordbooks, setWordbooks] = useState<AsyncState<Wordbook[]>>({ status: 'idle' });
+
+  // 단어장 생성 플로우 - 단어장 이름 상태 및 모달 open/close 핸들러
+  const [wordbookName, setWordbookName] = useState<string>('');
+  const open = useModalStore((s) => s.open);
+  const close = useModalStore((s) => s.close);
 
   const handleNavigate = (id: string) => {
     const path = ROUTES.WORDBOOK_DETAIL.replace(':wordbookId', String(id));
@@ -40,6 +47,23 @@ export const WordbooksPage = () => {
     }
   };
 
+  const createWordbookModalContent = () => {
+    return (
+      <CreateWordbookModal
+        value={wordbookName}
+        onChange={setWordbookName}
+        onSubmit={() => {
+          // TODO: 단어장 생성 API 연동 및 라우팅 로직 추가
+          alert(`단어장 "${wordbookName}"이(가) 생성되었습니다!`);
+          close('wordbook-create-modal');
+        }}
+        onCancel={() => {
+          close('wordbook-create-modal');
+        }}
+      />
+    );
+  };
+
   switch (wordbooks.status) {
     case 'idle':
     case 'loading':
@@ -55,6 +79,8 @@ export const WordbooksPage = () => {
       handleTabClick={handleTabClick}
       wordbooks={wordbooks.data}
       handleNavigate={handleNavigate}
+      openWordbookCreateModal={open}
+      createWordbookModalContent={createWordbookModalContent()}
     />
   );
 };

--- a/src/components/templates/WordbooksPageTemplate/WordbooksPageTemplate.tsx
+++ b/src/components/templates/WordbooksPageTemplate/WordbooksPageTemplate.tsx
@@ -1,4 +1,5 @@
 import { Header } from '@/components/organisms/Header/Header';
+import { ModalPortal } from '@/components/organisms/ModalPortal/ModalPortal';
 import { TabSwitcher, type Tab } from '@/components/organisms/TabSwitcher/TabSwitcher';
 import { WordbookList } from '@/components/organisms/WordbookList/WordbookList';
 import type { Wordbook } from '@/domain/wordbook';
@@ -9,6 +10,8 @@ type Props = {
   handleTabClick: (tab: Tab) => Promise<void> | void;
   wordbooks: Wordbook[];
   handleNavigate: (id: string) => Promise<void> | void;
+  openWordbookCreateModal: (modalId: string) => void;
+  createWordbookModalContent: React.ReactNode;
 };
 
 export const WordbooksPageTemplate = ({
@@ -17,16 +20,25 @@ export const WordbooksPageTemplate = ({
   handleTabClick,
   wordbooks,
   handleNavigate,
+  openWordbookCreateModal,
+  createWordbookModalContent,
 }: Props) => {
   return (
     <div className="flex h-full w-full flex-col items-center bg-gray-100">
       <Header title="Wordbooks Page" variant="basic" />
       <main className="mt-[2.25rem] flex min-h-0 w-full flex-1 flex-col items-center px-[1.25rem]">
         <TabSwitcher tabs={tabs} activeTab={activeTab} onChange={handleTabClick} />
-        <div className="mt-[1.25rem] mb-[2.25rem] w-full flex-1 overflow-y-auto">
+        <div className="mt-[1.25rem] mb-[2.25rem] flex w-full flex-1 flex-col gap-[1rem] overflow-y-auto">
           <WordbookList wordbooks={wordbooks} handleNavigate={handleNavigate} />
+          <button
+            className="flex h-[36px] items-center justify-center rounded-full bg-[#e9e9e9] py-[8px] text-lg text-[#9d9d9d]"
+            onClick={() => openWordbookCreateModal('wordbook-create-modal')}
+          >
+            <div className="flex items-center justify-center leading-none">+</div>
+          </button>
         </div>
       </main>
+      <ModalPortal id="wordbook-create-modal">{createWordbookModalContent}</ModalPortal>
     </div>
   );
 };


### PR DESCRIPTION
## 🫧 요약

- 단어장 추가 버튼 클릭 시 단어장 생성 모달이 뜨도록 합니다.

## ✅ 작업 내용

- Input 컴포넌트 제작 : 단어장 이름 입력
- 단어장 생성 모달 제작 및 화면 연동

## 🧪 테스트 방법

- 단어장 목록 페이지에서 "+ 버튼" 클릭
- 단어장 생성 모달이 뜨는지 확인
- 단어장 이름 입력 후 "생성" 버튼을 누르면 알러트가 뜨는지 확인

## ❣️ 관련 이슈

- close #65

## ☝️ 참고 사항

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 단어장 생성 모달: 단어장 목록에서 이름 입력 후 생성 또는 취소할 수 있는 모달이 추가되어 단어장 생성 흐름이 개선되었습니다.
  * 입력 컴포넌트 추가: 일관된 스타일과 속성을 가진 재사용 가능한 입력 필드가 도입되어 여러 화면에서 사용됩니다.
* **문서**
  * 입력 컴포넌트용 스토리(샘플)가 추가되어 컴포넌트 사용 예시를 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->