### PR TITLE
[CHORE] 변경된 API 응답 스펙 적용

### DIFF
--- a/src/apis/user/types.ts
+++ b/src/apis/user/types.ts
@@ -1,4 +1,5 @@
 export type GetUserProfileDataResponse = {
+  id: string;
   email: string;
   nickname: string;
   avatar_url: string;

--- a/src/apis/word/types.ts
+++ b/src/apis/word/types.ts
@@ -10,11 +10,11 @@ export interface WordResponse {
 }
 
 export type PartOfSpeechResponse =
-  | 'noun'
-  | 'pronoun'
-  | 'verb'
-  | 'adjective'
-  | 'adverb'
-  | 'preposition'
-  | 'conjunction'
-  | 'interjection';
+  | 'NOUN'
+  | 'PRONOUN'
+  | 'VERB'
+  | 'ADJECTIVE'
+  | 'ADVERB'
+  | 'PREPOSITION'
+  | 'CONJUNCTION'
+  | 'INTERJECTION';

--- a/src/apis/wordbook/types.ts
+++ b/src/apis/wordbook/types.ts
@@ -3,7 +3,7 @@ export type GetWordbookListResponse = {
   wordbook: {
     id: string;
     title: string;
-    description: string;
+    description: string | null;
     type: 'SYSTEM' | 'USER';
   };
 }[];

--- a/src/domain/user.ts
+++ b/src/domain/user.ts
@@ -1,4 +1,5 @@
 export type Profile = {
+  id: string;
   email: string;
   name: string;
   profile_image_url: string;

--- a/src/mapper/user.ts
+++ b/src/mapper/user.ts
@@ -3,6 +3,7 @@ import type { Profile } from '@/domain/user';
 
 export const mapUserProfileResponseToDomain = (response: GetUserProfileDataResponse): Profile => {
   return {
+    id: response.id,
     email: response.email,
     name: response.nickname,
     profile_image_url: response.avatar_url,

--- a/src/mapper/word.ts
+++ b/src/mapper/word.ts
@@ -8,7 +8,7 @@ export const mapWordResponseToDomain = (data: WordResponse): Word => {
     meanings: data.meanings
       .sort((a, b) => a.order_index - b.order_index)
       .map<Meaning>((m) => ({
-        partOfSpeech: m.part_of_speech,
+        partOfSpeech: POS_RESPONSE_DOMAIN_MAP[m.part_of_speech],
         textKo: m.meaning,
       })),
   };
@@ -21,14 +21,14 @@ export const mapWordListResponseToDomain = (data: WordResponse[]): Word[] => {
 export type PartOfSpeechLabel = 'n' | 'pron' | 'v' | 'adj' | 'adv' | 'prep' | 'conj' | 'interj';
 
 export const POS_RESPONSE_DOMAIN_MAP: Record<PartOfSpeechResponse, PartOfSpeech> = {
-  noun: 'noun',
-  pronoun: 'pronoun',
-  verb: 'verb',
-  adjective: 'adjective',
-  adverb: 'adverb',
-  preposition: 'preposition',
-  conjunction: 'conjunction',
-  interjection: 'interjection',
+  NOUN: 'noun',
+  PRONOUN: 'pronoun',
+  VERB: 'verb',
+  ADJECTIVE: 'adjective',
+  ADVERB: 'adverb',
+  PREPOSITION: 'preposition',
+  CONJUNCTION: 'conjunction',
+  INTERJECTION: 'interjection',
 };
 
 export const POS_DOMAIN_LABEL_MAP: Record<PartOfSpeech, PartOfSpeechLabel> = {

--- a/src/mapper/wordbook.ts
+++ b/src/mapper/wordbook.ts
@@ -7,7 +7,7 @@ export const mapWordbook = (item: WordbookResponseItem): Wordbook => {
   return {
     id: item.wordbook.id,
     title: item.wordbook.title,
-    description: item.wordbook.description,
+    description: item.wordbook.description ?? '',
     type: item.wordbook.type,
   };
 };


### PR DESCRIPTION
## 🫧 요약

- 변경된 API 응답 스펙 적용

## ✅ 작업 내용

- 품사 enum 소문자 -> 대문자 변경
- 사용자 프로필 조회 id 필드 추가
- 단어장 description nullable

## 🧪 테스트 방법

## 📷 참고 자료 - 스크린샷 / 링크 / GIF / ...

## ❣️ 관련 이슈

- close #ISSUE_NUMBER

## ☝️ 참고 사항

- 참고하세요~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 사용자 프로필에 ID 필드가 추가되어 프로필 정보가 완전해졌습니다.
  * 단어장 항목의 설명이 없을 때도 정상 표시되도록 처리했습니다.
* **개선**
  * 단어 품사 표기를 일관된 형식으로 정규화하여 표시 안정성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->