### PR TITLE
[CHORE] 사용자 단어장 편집 케밥 메뉴 추가 / 시스템 단어장 추가 UI 삭제

### DIFF
--- a/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
+++ b/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
@@ -98,7 +98,7 @@ export const UserWordbookDetailPage = () => {
     });
   };
 
-  const CREATE_WORD_MODAL = 'create-word-modal';
+  const CREATE_WORD_MODAL_ID = 'create-word-modal';
 
   const resetCreateWordForm = () => {
     setNewWord(createEmptyWord());
@@ -108,17 +108,17 @@ export const UserWordbookDetailPage = () => {
     setWords((prev) => [...prev, newWord]);
 
     resetCreateWordForm();
-    closeCreateWordModal(CREATE_WORD_MODAL);
+    closeCreateWordModal(CREATE_WORD_MODAL_ID);
   };
 
   const handleCreateWordCancel = () => {
     resetCreateWordForm();
-    closeCreateWordModal(CREATE_WORD_MODAL);
+    closeCreateWordModal(CREATE_WORD_MODAL_ID);
   };
 
   const handleOpenCreateWordModal = () => {
     resetCreateWordForm();
-    openCreateWordModal(CREATE_WORD_MODAL);
+    openCreateWordModal(CREATE_WORD_MODAL_ID);
   };
 
   const handleNavigate = () => {
@@ -133,7 +133,7 @@ export const UserWordbookDetailPage = () => {
       handleKebabMenuOpen={handleKebabMenuOpen}
       kebabAnchorRef={kebabButtonRef}
       // create word modal props
-      createWordModalId={CREATE_WORD_MODAL}
+      createWordModalId={CREATE_WORD_MODAL_ID}
       newWord={newWord}
       isCreateWordValid={isCreateWordValid}
       onEngChange={handleEngChange}

--- a/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
+++ b/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
@@ -100,20 +100,24 @@ export const UserWordbookDetailPage = () => {
 
   const CREATE_WORD_MODAL = 'create-word-modal';
 
+  const resetCreateWordForm = () => {
+    setNewWord(createEmptyWord());
+  };
+
   const handleCreateWordSubmit = () => {
     setWords((prev) => [...prev, newWord]);
 
-    setNewWord(createEmptyWord()); // 입력 폼 초기화
+    resetCreateWordForm();
     closeCreateWordModal(CREATE_WORD_MODAL);
   };
 
   const handleCreateWordCancel = () => {
-    setNewWord(createEmptyWord());
+    resetCreateWordForm();
     closeCreateWordModal(CREATE_WORD_MODAL);
   };
 
   const handleOpenCreateWordModal = () => {
-    setNewWord(createEmptyWord());
+    resetCreateWordForm();
     openCreateWordModal(CREATE_WORD_MODAL);
   };
 
@@ -139,6 +143,7 @@ export const UserWordbookDetailPage = () => {
       onDeleteMeaning={handleDeleteMeaning}
       onSubmit={handleCreateWordSubmit}
       onCancel={handleCreateWordCancel}
+      onClose={resetCreateWordForm}
       onNavigate={handleNavigate}
       onOpenCreateWordModal={handleOpenCreateWordModal}
     />

--- a/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
+++ b/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
@@ -1,6 +1,6 @@
 import type { PartOfSpeech, Word } from '@/domain/word';
 import { useModalStore } from '@/store/useModalStore';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { UserWordbookDetailPageTemplate } from '@/components/templates/UserWordbookDetailPageTemplate/UserWordbookDetailPageTemplate';
 import { ROUTES } from '@/router/path';
 import { useNavigate } from 'react-router-dom';
@@ -20,12 +20,21 @@ export const UserWordbookDetailPage = () => {
   const [words, setWords] = useState<Word[]>([]);
   const [newWord, setNewWord] = useState<Word>(createEmptyWord());
 
+  // Header kebab menu
+  const [isKebabMenuOpen, setIsKebabMenuOpen] = useState<boolean>(false);
+  const kebabButtonRef = useRef<HTMLButtonElement | null>(null);
+
   const openCreateWordModal = useModalStore((s) => s.open);
   const closeCreateWordModal = useModalStore((s) => s.close);
 
   const isCreateWordValid =
     newWord.textEn.trim() !== '' &&
     newWord.meanings.every((meaning) => meaning.textKo.trim() !== '');
+
+  const handleKebabMenuOpen = (flag: boolean) => {
+    if (flag) setIsKebabMenuOpen(true);
+    else setIsKebabMenuOpen(false);
+  };
 
   const handleEngChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
@@ -115,6 +124,11 @@ export const UserWordbookDetailPage = () => {
   return (
     <UserWordbookDetailPageTemplate
       words={words}
+      // kebab menu props
+      isKebabMenuOpen={isKebabMenuOpen}
+      handleKebabMenuOpen={handleKebabMenuOpen}
+      kebabAnchorRef={kebabButtonRef}
+      // create word modal props
       createWordModalId={CREATE_WORD_MODAL}
       newWord={newWord}
       isCreateWordValid={isCreateWordValid}

--- a/src/components/pages/WordbooksPage/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage/WordbooksPage.tsx
@@ -42,7 +42,7 @@ export const WordbooksPage = () => {
   const handleTabClick = (tab: Tab) => {
     if (tab.disabled) {
       alert('서비스 준비중입니다.');
-    } else if (tab.disabled === false) {
+    } else {
       setActiveTab(tab.id);
     }
   };
@@ -83,7 +83,9 @@ export const WordbooksPage = () => {
       tabs={tabs}
       activeTab={activeTab}
       handleTabClick={handleTabClick}
-      wordbooks={wordbooks.data}
+      wordbooks={
+        tabs.find((tab) => tab.id === activeTab)?.label === '커리큘럼' ? wordbooks.data : [] // TODO: 내 단어장 목록 API 연동 필요
+      }
       handleNavigate={handleNavigate}
       openWordbookCreateModal={open}
       createWordbookModalContent={createWordbookModalContent()}
@@ -94,5 +96,5 @@ export const WordbooksPage = () => {
 // 정적 데이터
 const tabs: Tab[] = [
   { id: 1, label: '커리큘럼' },
-  { id: 2, label: '내 단어장', disabled: true },
+  { id: 2, label: '내 단어장' },
 ];

--- a/src/components/pages/WordbooksPage/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage/WordbooksPage.tsx
@@ -6,11 +6,18 @@ import { getWordbookList } from '@/apis/wordbook';
 import type { Wordbook } from '@/domain/wordbook';
 import type { AsyncState } from '@/shared/types/asyncState';
 import { WordbooksPageTemplate } from '@/components/templates/WordbooksPageTemplate/WordbooksPageTemplate';
+import { useModalStore } from '@/store/useModalStore';
+import { CreateWordbookModal } from '@/components/organisms/CreateWordbookModal/CreateWordbookModal';
 
 export const WordbooksPage = () => {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<number>(1);
   const [wordbooks, setWordbooks] = useState<AsyncState<Wordbook[]>>({ status: 'idle' });
+
+  // 단어장 생성 플로우 - 단어장 이름 상태 및 모달 open/close 핸들러
+  const [wordbookName, setWordbookName] = useState<string>('');
+  const open = useModalStore((s) => s.open);
+  const close = useModalStore((s) => s.close);
 
   const handleNavigate = (id: string) => {
     const path = ROUTES.WORDBOOK_DETAIL.replace(':wordbookId', String(id));
@@ -40,6 +47,29 @@ export const WordbooksPage = () => {
     }
   };
 
+  const createWordbookModalContent = () => {
+    return (
+      <CreateWordbookModal
+        value={wordbookName}
+        onChange={setWordbookName}
+        onSubmit={() => {
+          if (wordbookName.trim() === '') {
+            alert('단어장 이름을 입력해주세요.');
+            return;
+          }
+          // TODO: 단어장 생성 API 연동 및 라우팅 로직 추가
+          alert(`단어장 "${wordbookName}"이(가) 생성되었습니다!`);
+          setWordbookName('');
+          close('wordbook-create-modal');
+        }}
+        onCancel={() => {
+          setWordbookName('');
+          close('wordbook-create-modal');
+        }}
+      />
+    );
+  };
+
   switch (wordbooks.status) {
     case 'idle':
     case 'loading':
@@ -55,6 +85,8 @@ export const WordbooksPage = () => {
       handleTabClick={handleTabClick}
       wordbooks={wordbooks.data}
       handleNavigate={handleNavigate}
+      openWordbookCreateModal={open}
+      createWordbookModalContent={createWordbookModalContent()}
     />
   );
 };

--- a/src/components/pages/WordbooksPage/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage/WordbooksPage.tsx
@@ -6,18 +6,11 @@ import { getWordbookList } from '@/apis/wordbook';
 import type { Wordbook } from '@/domain/wordbook';
 import type { AsyncState } from '@/shared/types/asyncState';
 import { WordbooksPageTemplate } from '@/components/templates/WordbooksPageTemplate/WordbooksPageTemplate';
-import { useModalStore } from '@/store/useModalStore';
-import { CreateWordbookModal } from '@/components/organisms/CreateWordbookModal/CreateWordbookModal';
 
 export const WordbooksPage = () => {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<number>(1);
   const [wordbooks, setWordbooks] = useState<AsyncState<Wordbook[]>>({ status: 'idle' });
-
-  // 단어장 생성 플로우 - 단어장 이름 상태 및 모달 open/close 핸들러
-  const [wordbookName, setWordbookName] = useState<string>('');
-  const open = useModalStore((s) => s.open);
-  const close = useModalStore((s) => s.close);
 
   const handleNavigate = (id: string) => {
     const path = ROUTES.WORDBOOK_DETAIL.replace(':wordbookId', String(id));
@@ -47,29 +40,6 @@ export const WordbooksPage = () => {
     }
   };
 
-  const createWordbookModalContent = () => {
-    return (
-      <CreateWordbookModal
-        value={wordbookName}
-        onChange={setWordbookName}
-        onSubmit={() => {
-          if (wordbookName.trim() === '') {
-            alert('단어장 이름을 입력해주세요.');
-            return;
-          }
-          // TODO: 단어장 생성 API 연동 및 라우팅 로직 추가
-          alert(`단어장 "${wordbookName}"이(가) 생성되었습니다!`);
-          setWordbookName('');
-          close('wordbook-create-modal');
-        }}
-        onCancel={() => {
-          setWordbookName('');
-          close('wordbook-create-modal');
-        }}
-      />
-    );
-  };
-
   switch (wordbooks.status) {
     case 'idle':
     case 'loading':
@@ -85,8 +55,6 @@ export const WordbooksPage = () => {
       handleTabClick={handleTabClick}
       wordbooks={wordbooks.data}
       handleNavigate={handleNavigate}
-      openWordbookCreateModal={open}
-      createWordbookModalContent={createWordbookModalContent()}
     />
   );
 };

--- a/src/components/pages/WordbooksPage/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage/WordbooksPage.tsx
@@ -83,9 +83,11 @@ export const WordbooksPage = () => {
       tabs={tabs}
       activeTab={activeTab}
       handleTabClick={handleTabClick}
-      wordbooks={
-        tabs.find((tab) => tab.id === activeTab)?.label === '커리큘럼' ? wordbooks.data : [] // TODO: 내 단어장 목록 API 연동 필요
-      }
+      wordbooks={wordbooks.data.filter((wordbook) =>
+        tabs.find((tab) => tab.id === activeTab)?.label === '커리큘럼'
+          ? wordbook.type === 'SYSTEM'
+          : wordbook.type === 'USER',
+      )}
       handleNavigate={handleNavigate}
       openWordbookCreateModal={open}
       createWordbookModalContent={createWordbookModalContent()}

--- a/src/components/pages/WordbooksPage/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage/WordbooksPage.tsx
@@ -47,6 +47,17 @@ export const WordbooksPage = () => {
     }
   };
 
+  const CREATE_WORDBOOK_MODAL_ID = 'create-wordbook-modal';
+
+  const resetCreateWordbookForm = () => {
+    setWordbookName('');
+  };
+
+  const handleCreateWordbookCancel = () => {
+    resetCreateWordbookForm();
+    close(CREATE_WORDBOOK_MODAL_ID);
+  };
+
   const createWordbookModalContent = () => {
     return (
       <CreateWordbookModal
@@ -59,13 +70,10 @@ export const WordbooksPage = () => {
           }
           // TODO: 단어장 생성 API 연동 및 라우팅 로직 추가
           alert(`단어장 "${wordbookName}"이(가) 생성되었습니다!`);
-          setWordbookName('');
-          close('wordbook-create-modal');
+          resetCreateWordbookForm();
+          close(CREATE_WORDBOOK_MODAL_ID);
         }}
-        onCancel={() => {
-          setWordbookName('');
-          close('wordbook-create-modal');
-        }}
+        onCancel={handleCreateWordbookCancel}
       />
     );
   };
@@ -89,7 +97,9 @@ export const WordbooksPage = () => {
           : wordbook.type === 'USER',
       )}
       handleNavigate={handleNavigate}
-      openWordbookCreateModal={open}
+      createWordbookModalId={CREATE_WORDBOOK_MODAL_ID}
+      onOpenWordbookCreateModal={() => open(CREATE_WORDBOOK_MODAL_ID)}
+      onClose={resetCreateWordbookForm}
       createWordbookModalContent={createWordbookModalContent()}
     />
   );

--- a/src/components/templates/UserWordbookDetailPageTemplate/UserWordbookDetailPageTemplate.tsx
+++ b/src/components/templates/UserWordbookDetailPageTemplate/UserWordbookDetailPageTemplate.tsx
@@ -28,6 +28,7 @@ interface Props {
   onDeleteMeaning: (idxToDelete: number) => void;
   onSubmit: () => void;
   onCancel: () => void;
+  onClose: () => void;
 
   /** Header actions */
   onNavigate: () => void;
@@ -50,6 +51,7 @@ export const UserWordbookDetailPageTemplate = ({
   onDeleteMeaning,
   onSubmit,
   onCancel,
+  onClose,
   onNavigate,
   onOpenCreateWordModal,
 }: Props) => {
@@ -90,7 +92,7 @@ export const UserWordbookDetailPageTemplate = ({
         ]}
       />
 
-      <ModalPortal id={createWordModalId}>
+      <ModalPortal id={createWordModalId} onClose={onClose}>
         <CreateWordModalContent
           newWord={newWord}
           isCreateWordValid={isCreateWordValid}

--- a/src/components/templates/UserWordbookDetailPageTemplate/UserWordbookDetailPageTemplate.tsx
+++ b/src/components/templates/UserWordbookDetailPageTemplate/UserWordbookDetailPageTemplate.tsx
@@ -1,15 +1,23 @@
-import React from 'react';
+import React, { type RefObject } from 'react';
 import { Header } from '@/components/organisms/Header/Header';
 import { ModalPortal } from '@/components/organisms/ModalPortal/ModalPortal';
 import { WordList } from '@/components/organisms/WordList/WordList';
 import { CreateWordModalContent } from '@/components/organisms/CreateWordModal/CreateWordModalContent';
 import type { PartOfSpeech, Word } from '@/domain/word';
+import { KebabMenu } from '@/components/organisms/KebabMenu/KebabMenu';
 
 interface Props {
   title?: string;
   words: Word[];
+
+  /** kebab menu props */
+  isKebabMenuOpen: boolean;
+  handleKebabMenuOpen: (flag: boolean) => Promise<void> | void;
+  kebabAnchorRef: RefObject<HTMLButtonElement | null>;
+
   /** ModalPortal id */
   createWordModalId: string;
+
   /** CreateWordModalContent props */
   newWord: Word;
   isCreateWordValid: boolean;
@@ -20,6 +28,7 @@ interface Props {
   onDeleteMeaning: (idxToDelete: number) => void;
   onSubmit: () => void;
   onCancel: () => void;
+
   /** Header actions */
   onNavigate: () => void;
   onOpenCreateWordModal: () => void;
@@ -28,6 +37,9 @@ interface Props {
 export const UserWordbookDetailPageTemplate = ({
   title = '단어장 상세 페이지',
   words,
+  isKebabMenuOpen,
+  handleKebabMenuOpen,
+  kebabAnchorRef,
   createWordModalId,
   newWord,
   isCreateWordValid,
@@ -48,13 +60,35 @@ export const UserWordbookDetailPageTemplate = ({
         variant="LRCTA"
         LCTAIcon="ChevronLeft"
         onLCTAClick={onNavigate}
-        RCTAIcon="Plus"
-        onRCTAClick={onOpenCreateWordModal}
+        RCTAIcon="DotsVertical"
+        onRCTAClick={() => handleKebabMenuOpen(true)}
+        RCTARef={kebabAnchorRef}
       />
 
       <div className="mt-[0.5rem] flex min-h-0 w-full flex-1 flex-col overflow-y-auto">
         <WordList words={words} />
       </div>
+
+      {/* 휘발성 오버레이 */}
+      <KebabMenu
+        open={isKebabMenuOpen}
+        anchorRef={kebabAnchorRef}
+        onClose={() => handleKebabMenuOpen(false)}
+        UIProps={[
+          {
+            label: '단어 생성하기',
+            handleClick: onOpenCreateWordModal,
+          },
+          {
+            label: '단어 삭제하기',
+            handleClick: () => alert('준비 중입니다.'),
+          },
+          {
+            label: '단어장 삭제하기',
+            handleClick: () => alert('준비 중입니다.'),
+          },
+        ]}
+      />
 
       <ModalPortal id={createWordModalId}>
         <CreateWordModalContent

--- a/src/components/templates/WordbooksPageTemplate/WordbooksPageTemplate.tsx
+++ b/src/components/templates/WordbooksPageTemplate/WordbooksPageTemplate.tsx
@@ -1,4 +1,5 @@
 import { Header } from '@/components/organisms/Header/Header';
+import { ModalPortal } from '@/components/organisms/ModalPortal/ModalPortal';
 import { TabSwitcher, type Tab } from '@/components/organisms/TabSwitcher/TabSwitcher';
 import { WordbookList } from '@/components/organisms/WordbookList/WordbookList';
 import type { Wordbook } from '@/domain/wordbook';
@@ -9,6 +10,8 @@ type Props = {
   handleTabClick: (tab: Tab) => Promise<void> | void;
   wordbooks: Wordbook[];
   handleNavigate: (id: string) => Promise<void> | void;
+  openWordbookCreateModal: (modalId: string) => void;
+  createWordbookModalContent: React.ReactNode;
 };
 
 export const WordbooksPageTemplate = ({
@@ -17,16 +20,25 @@ export const WordbooksPageTemplate = ({
   handleTabClick,
   wordbooks,
   handleNavigate,
+  openWordbookCreateModal,
+  createWordbookModalContent,
 }: Props) => {
   return (
     <div className="flex h-full w-full flex-col items-center bg-gray-100">
       <Header title="Wordbooks Page" variant="basic" />
       <main className="mt-[2.25rem] flex min-h-0 w-full flex-1 flex-col items-center px-[1.25rem]">
         <TabSwitcher tabs={tabs} activeTab={activeTab} onChange={handleTabClick} />
-        <div className="mt-[1.25rem] mb-[2.25rem] flex w-full flex-1 flex-col overflow-y-auto">
+        <div className="mt-[1.25rem] mb-[2.25rem] flex w-full flex-1 flex-col gap-[1rem] overflow-y-auto">
           <WordbookList wordbooks={wordbooks} handleNavigate={handleNavigate} />
+          <button
+            className="flex h-[36px] items-center justify-center rounded-full bg-[#e9e9e9] py-[8px] text-lg text-[#9d9d9d]"
+            onClick={() => openWordbookCreateModal('wordbook-create-modal')}
+          >
+            <div className="flex items-center justify-center leading-none">+</div>
+          </button>
         </div>
       </main>
+      <ModalPortal id="wordbook-create-modal">{createWordbookModalContent}</ModalPortal>
     </div>
   );
 };

--- a/src/components/templates/WordbooksPageTemplate/WordbooksPageTemplate.tsx
+++ b/src/components/templates/WordbooksPageTemplate/WordbooksPageTemplate.tsx
@@ -1,5 +1,4 @@
 import { Header } from '@/components/organisms/Header/Header';
-import { ModalPortal } from '@/components/organisms/ModalPortal/ModalPortal';
 import { TabSwitcher, type Tab } from '@/components/organisms/TabSwitcher/TabSwitcher';
 import { WordbookList } from '@/components/organisms/WordbookList/WordbookList';
 import type { Wordbook } from '@/domain/wordbook';
@@ -10,8 +9,6 @@ type Props = {
   handleTabClick: (tab: Tab) => Promise<void> | void;
   wordbooks: Wordbook[];
   handleNavigate: (id: string) => Promise<void> | void;
-  openWordbookCreateModal: (modalId: string) => void;
-  createWordbookModalContent: React.ReactNode;
 };
 
 export const WordbooksPageTemplate = ({
@@ -20,25 +17,16 @@ export const WordbooksPageTemplate = ({
   handleTabClick,
   wordbooks,
   handleNavigate,
-  openWordbookCreateModal,
-  createWordbookModalContent,
 }: Props) => {
   return (
     <div className="flex h-full w-full flex-col items-center bg-gray-100">
       <Header title="Wordbooks Page" variant="basic" />
       <main className="mt-[2.25rem] flex min-h-0 w-full flex-1 flex-col items-center px-[1.25rem]">
         <TabSwitcher tabs={tabs} activeTab={activeTab} onChange={handleTabClick} />
-        <div className="mt-[1.25rem] mb-[2.25rem] flex w-full flex-1 flex-col gap-[1rem] overflow-y-auto">
+        <div className="mt-[1.25rem] mb-[2.25rem] flex w-full flex-1 flex-col overflow-y-auto">
           <WordbookList wordbooks={wordbooks} handleNavigate={handleNavigate} />
-          <button
-            className="flex h-[36px] items-center justify-center rounded-full bg-[#e9e9e9] py-[8px] text-lg text-[#9d9d9d]"
-            onClick={() => openWordbookCreateModal('wordbook-create-modal')}
-          >
-            <div className="flex items-center justify-center leading-none">+</div>
-          </button>
         </div>
       </main>
-      <ModalPortal id="wordbook-create-modal">{createWordbookModalContent}</ModalPortal>
     </div>
   );
 };

--- a/src/components/templates/WordbooksPageTemplate/WordbooksPageTemplate.tsx
+++ b/src/components/templates/WordbooksPageTemplate/WordbooksPageTemplate.tsx
@@ -10,7 +10,9 @@ type Props = {
   handleTabClick: (tab: Tab) => Promise<void> | void;
   wordbooks: Wordbook[];
   handleNavigate: (id: string) => Promise<void> | void;
-  openWordbookCreateModal: (modalId: string) => void;
+  createWordbookModalId: string;
+  onOpenWordbookCreateModal: () => void;
+  onClose: () => void;
   createWordbookModalContent: React.ReactNode;
 };
 
@@ -20,7 +22,9 @@ export const WordbooksPageTemplate = ({
   handleTabClick,
   wordbooks,
   handleNavigate,
-  openWordbookCreateModal,
+  createWordbookModalId,
+  onOpenWordbookCreateModal,
+  onClose,
   createWordbookModalContent,
 }: Props) => {
   return (
@@ -32,7 +36,7 @@ export const WordbooksPageTemplate = ({
           {tabs.find((tab) => tab.id === activeTab)?.label === '내 단어장' && (
             <button
               className="flex h-[36px] items-center justify-center rounded-full bg-[#e9e9e9] py-[8px] text-lg text-[#9d9d9d]"
-              onClick={() => openWordbookCreateModal('wordbook-create-modal')}
+              onClick={onOpenWordbookCreateModal}
             >
               <div className="flex items-center justify-center leading-none">+</div>
             </button>
@@ -40,7 +44,9 @@ export const WordbooksPageTemplate = ({
           <WordbookList wordbooks={wordbooks} handleNavigate={handleNavigate} />
         </div>
       </main>
-      <ModalPortal id="wordbook-create-modal">{createWordbookModalContent}</ModalPortal>
+      <ModalPortal id={createWordbookModalId} onClose={onClose}>
+        {createWordbookModalContent}
+      </ModalPortal>
     </div>
   );
 };

--- a/src/components/templates/WordbooksPageTemplate/WordbooksPageTemplate.tsx
+++ b/src/components/templates/WordbooksPageTemplate/WordbooksPageTemplate.tsx
@@ -29,13 +29,15 @@ export const WordbooksPageTemplate = ({
       <main className="mt-[2.25rem] flex min-h-0 w-full flex-1 flex-col items-center px-[1.25rem]">
         <TabSwitcher tabs={tabs} activeTab={activeTab} onChange={handleTabClick} />
         <div className="mt-[1.25rem] mb-[2.25rem] flex w-full flex-1 flex-col gap-[1rem] overflow-y-auto">
+          {tabs.find((tab) => tab.id === activeTab)?.label === '내 단어장' && (
+            <button
+              className="flex h-[36px] items-center justify-center rounded-full bg-[#e9e9e9] py-[8px] text-lg text-[#9d9d9d]"
+              onClick={() => openWordbookCreateModal('wordbook-create-modal')}
+            >
+              <div className="flex items-center justify-center leading-none">+</div>
+            </button>
+          )}
           <WordbookList wordbooks={wordbooks} handleNavigate={handleNavigate} />
-          <button
-            className="flex h-[36px] items-center justify-center rounded-full bg-[#e9e9e9] py-[8px] text-lg text-[#9d9d9d]"
-            onClick={() => openWordbookCreateModal('wordbook-create-modal')}
-          >
-            <div className="flex items-center justify-center leading-none">+</div>
-          </button>
         </div>
       </main>
       <ModalPortal id="wordbook-create-modal">{createWordbookModalContent}</ModalPortal>


### PR DESCRIPTION
## 🫧 요약

- UI 변경사항을 적용합니다.

## ✅ 작업 내용

- 사용자 단어장 편집 케밥 메뉴 추가
  - 단어 생성에만 핸들러 연결
  - 단어 및 단어장 삭제는 임시 alert 연결
- 단어장 추가 버튼 나의 단어장 목록 탭에서만 보이도록 변경

## 🧪 테스트 방법
- `http://localhost:5173/user/wordbook/단어장 id/wordbook-detail`
- `http://localhost:5173/wordbooks`

## 📷 참고 자료 - 스크린샷 / 링크 / GIF / ...
<img width="442" height="262" alt="image" src="https://github.com/user-attachments/assets/d5831979-1818-4d68-91ad-04151600f9aa" />

## ❣️ 관련 이슈

- close #ISSUE_NUMBER

## ☝️ 참고 사항

- 참고하세요~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * 단어장 상세 화면 헤더 작업 버튼이 메뉴(점 3개) 형태로 변경되어 “단어 생성하기” 등 작업을 한 곳에서 확인할 수 있습니다.

* **Bug Fixes**
  * 단어장 목록 탭 전환 시 비활성 탭은 안내만 표시하고, 활성 탭에 따라 단어장 데이터가 조건에 맞게 필터링되도록 개선했습니다.
  * 생성 모달 관련 초기화/닫기 흐름을 정리해 불필요한 동작을 줄였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->