### PR TITLE
[FEAT] 사용자 단어장 목록 조회 api 연동

### DIFF
--- a/src/apis/wordbook/index.ts
+++ b/src/apis/wordbook/index.ts
@@ -1,5 +1,5 @@
 import type { Wordbook } from '@/domain/wordbook';
-import { mapWordbookList } from '@/mapper/wordbook';
+import { mapWordbookList, mapUserWordbookList } from '@/mapper/wordbook';
 import { api } from '@/apis/axiosInstance';
 
 export const getWordbookList = async (): Promise<Wordbook[]> => {
@@ -8,6 +8,16 @@ export const getWordbookList = async (): Promise<Wordbook[]> => {
     return mapWordbookList(res.data);
   } catch (error) {
     console.error('[ERROR] 단어장 목록 조회 실패: ', error);
+    throw error;
+  }
+};
+
+export const getUserWordbookList = async (): Promise<Wordbook[]> => {
+  try {
+    const res = await api.get('/wordbooks/user');
+    return mapUserWordbookList(res.data);
+  } catch (error) {
+    console.error('[ERROR] 사용자 단어장 목록 조회 실패: ', error);
     throw error;
   }
 };

--- a/src/apis/wordbook/types.ts
+++ b/src/apis/wordbook/types.ts
@@ -7,3 +7,10 @@ export type GetWordbookListResponse = {
     type: 'SYSTEM' | 'USER';
   };
 }[];
+
+export type GetWordbookResponse = {
+  id: string;
+  title: string;
+  description: string | null;
+  type: 'SYSTEM' | 'USER';
+};

--- a/src/components/pages/WordbookDetailPage/WordbookDetailPage.tsx
+++ b/src/components/pages/WordbookDetailPage/WordbookDetailPage.tsx
@@ -3,19 +3,18 @@ import { useEffect, useRef, useState } from 'react';
 import type { Word } from '@/domain/word';
 import { getWordList } from '@/apis/word';
 import type { AsyncState } from '@/shared/types/asyncState';
+import { combineAsyncStates } from '@/shared/types/asyncState';
 import { WordbookDetailPageTemplate } from '@/components/templates/WordbookDetailPageTemplate/WordbookDetailPageTemplate';
 import { ROUTES } from '@/router/path';
 import { useModalStore } from '@/store/useModalStore';
-import { MOCK_WORDBOOKS_10 } from '@/components/pages/WordbookDetailPage/mock';
 import type { Wordbook } from '@/domain/wordbook';
 import { useWordSelection } from '@/hooks/useWordSelection';
+import { getUserWordbookList } from '@/apis/wordbook';
 
 export const WordbookDetailPage = () => {
   const navigate = useNavigate();
   const [words, setWords] = useState<AsyncState<Word[]>>({ status: 'idle' });
   const { wordbookId } = useParams<{ wordbookId: string }>();
-
-  // interactive ui state
 
   // Header kebab menu
   const [isKebabMenuOpen, setIsKebabMenuOpen] = useState<boolean>(false);
@@ -25,6 +24,7 @@ export const WordbookDetailPage = () => {
   const open = useModalStore((s) => s.open);
   const close = useModalStore((s) => s.close);
   const wordbookSelectModalId = 'wordbook-select-modal';
+  const [userWordbooks, setUserWordbooks] = useState<AsyncState<Wordbook[]>>({ status: 'idle' });
 
   // Wordbook create modal
   const wordbookCreateModalId = 'wordbook-create-modal';
@@ -113,9 +113,23 @@ export const WordbookDetailPage = () => {
     fetchWords();
   }, [wordbookId]);
 
-  // data status가 success가 아닐 때의 처리
+  useEffect(() => {
+    const fetchUserWordbooks = async () => {
+      try {
+        const data = await getUserWordbookList();
+        setUserWordbooks({ status: 'success', data });
+      } catch (_) {
+        setUserWordbooks({ status: 'error' });
+      }
+    };
+    fetchUserWordbooks();
+  }, []);
+
+  // page에서 모든 fetch data의 예외처리를 끝내고, template 이하는 완결된 데이터를 가정한다.
   // TODO: 로딩, 에러 UI/UX 기획 필요
-  switch (words.status) {
+  const pageData = combineAsyncStates(words, userWordbooks);
+
+  switch (pageData.status) {
     case 'idle':
     case 'loading':
       return <div>Loading...</div>;
@@ -123,9 +137,11 @@ export const WordbookDetailPage = () => {
       return <div>오류가 발생했습니다. 다시 시도해주세요.</div>;
   }
 
+  const [wordsData, userWordbooksData] = pageData.data;
+
   return (
     <WordbookDetailPageTemplate
-      words={words.data}
+      words={wordsData}
       handleNavigate={handleNavigate}
       // kebab menu props
       isKebabMenuOpen={isKebabMenuOpen}
@@ -135,7 +151,7 @@ export const WordbookDetailPage = () => {
       // wordbook select modal props
       wordbookSelectModal={{
         id: wordbookSelectModalId, // modal id
-        wordbooks: MOCK_WORDBOOKS_10, // fetch data
+        wordbooks: userWordbooksData, // fetch data
         handleSelectTargetWordbook, // action
         handleWordbookCreateModalOpen: () => open(wordbookCreateModalId), // action
       }}

--- a/src/mapper/wordbook.ts
+++ b/src/mapper/wordbook.ts
@@ -1,4 +1,4 @@
-import type { GetWordbookListResponse } from '@/apis/wordbook/types';
+import type { GetWordbookListResponse, GetWordbookResponse } from '@/apis/wordbook/types';
 import type { Wordbook } from '@/domain/wordbook';
 
 type WordbookResponseItem = GetWordbookListResponse[number];
@@ -12,6 +12,19 @@ export const mapWordbook = (item: WordbookResponseItem): Wordbook => {
   };
 };
 
+export const mapUserWordbook = (item: GetWordbookResponse): Wordbook => {
+  return {
+    id: item.id,
+    title: item.title,
+    description: item.description ?? '',
+    type: item.type,
+  };
+};
+
 export const mapWordbookList = (response: GetWordbookListResponse): Wordbook[] => {
   return response.map(mapWordbook);
+};
+
+export const mapUserWordbookList = (response: GetWordbookResponse[]): Wordbook[] => {
+  return response.map(mapUserWordbook);
 };

--- a/src/shared/types/asyncState.ts
+++ b/src/shared/types/asyncState.ts
@@ -3,3 +3,28 @@ export type AsyncState<T> =
   | { status: 'loading' }
   | { status: 'success'; data: T }
   | { status: 'error' };
+
+type AsyncDataTuple<T extends readonly AsyncState<unknown>[]> = {
+  [K in keyof T]: T[K] extends AsyncState<infer R> ? R : never;
+};
+
+export function combineAsyncStates<T extends readonly AsyncState<unknown>[]>(
+  ...states: T
+): AsyncState<AsyncDataTuple<T>> {
+  if (states.every((state) => state.status === 'idle')) {
+    return { status: 'idle' };
+  }
+
+  if (states.some((state) => state.status === 'error')) {
+    return { status: 'error' };
+  }
+
+  if (states.some((state) => state.status === 'loading' || state.status === 'idle')) {
+    return { status: 'loading' };
+  }
+
+  return {
+    status: 'success',
+    data: states.map((state) => (state as { data: unknown }).data) as AsyncDataTuple<T>,
+  };
+}


### PR DESCRIPTION
## 🫧 요약

- 사용자 단어장 목록 조회 api 연동

## ✅ 작업 내용

- 사용자 단어장 목록 조회 api 연동
- 여러 개의 AsyncState 를 통합하는 함수 작성

## 🧪 테스트 방법

- 시스템 단어장 하나 선택 -> 케밥 메뉴 클릭 -> 나의 단어장에 추가하기 버튼 클릭

## 📷 참고 자료 - 스크린샷 / 링크 / GIF / ...

<img width="356" height="722" alt="image" src="https://github.com/user-attachments/assets/0f28ea14-9efe-428d-9f6f-fb5551d67235" />

## ❣️ 관련 이슈

- close #76 

## ☝️ 참고 사항

- 참고하세요~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 사용자 전용 단어장 목록을 불러와 단어장 선택 화면에 반영합니다.
  * 여러 비동기 상태를 함께 처리해, 페이지 전체 로딩/오류 표시가 더 안정적으로 동작합니다.

* **Bug Fixes**
  * 더 이상 고정된 예시 데이터에만 의존하지 않고, 실제 사용자 단어장 목록을 보여줍니다.
  * 단어장 응답의 빈 설명값도 자연스럽게 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->