### PR TITLE
[FEAT] 사용자 단어장 생성 api 연동

### DIFF
--- a/src/apis/wordbook/index.ts
+++ b/src/apis/wordbook/index.ts
@@ -1,11 +1,11 @@
 import type { Wordbook } from '@/domain/wordbook';
-import { mapWordbookList, mapUserWordbookList } from '@/mapper/wordbook';
+import { mapOrderedWordbookList, mapWordbook, mapWordbookList } from '@/mapper/wordbook';
 import { api } from '@/apis/axiosInstance';
 
 export const getWordbookList = async (): Promise<Wordbook[]> => {
   try {
     const res = await api.get('/curriculums/default');
-    return mapWordbookList(res.data);
+    return mapOrderedWordbookList(res.data);
   } catch (error) {
     console.error('[ERROR] 단어장 목록 조회 실패: ', error);
     throw error;
@@ -15,9 +15,19 @@ export const getWordbookList = async (): Promise<Wordbook[]> => {
 export const getUserWordbookList = async (): Promise<Wordbook[]> => {
   try {
     const res = await api.get('/wordbooks/user');
-    return mapUserWordbookList(res.data);
+    return mapWordbookList(res.data);
   } catch (error) {
     console.error('[ERROR] 사용자 단어장 목록 조회 실패: ', error);
+    throw error;
+  }
+};
+
+export const createUserWordbook = async (title: string, description: string): Promise<Wordbook> => {
+  try {
+    const res = await api.post('/wordbooks', { title, description });
+    return mapWordbook(res.data);
+  } catch (error) {
+    console.error('[ERROR] 사용자 단어장 생성 실패: ', error);
     throw error;
   }
 };

--- a/src/apis/wordbook/index.ts
+++ b/src/apis/wordbook/index.ts
@@ -22,7 +22,10 @@ export const getUserWordbookList = async (): Promise<Wordbook[]> => {
   }
 };
 
-export const createUserWordbook = async (title: string, description: string): Promise<Wordbook> => {
+export const createUserWordbook = async (
+  title: string,
+  description: string | null,
+): Promise<Wordbook> => {
   try {
     const res = await api.post('/wordbooks', { title, description });
     return mapWordbook(res.data);

--- a/src/apis/wordbook/types.ts
+++ b/src/apis/wordbook/types.ts
@@ -1,16 +1,13 @@
-export type GetWordbookListResponse = {
-  order_index: number;
-  wordbook: {
-    id: string;
-    title: string;
-    description: string | null;
-    type: 'SYSTEM' | 'USER';
-  };
-}[];
-
-export type GetWordbookResponse = {
+// 단어장 응답 본문 (평탄한 형태)
+export type WordbookResponse = {
   id: string;
   title: string;
   description: string | null;
   type: 'SYSTEM' | 'USER';
+};
+
+// order_index로 감싼 형태 (정렬 순서를 가진 목록 응답)
+export type OrderedWordbookResponse = {
+  order_index: number;
+  wordbook: WordbookResponse;
 };

--- a/src/components/pages/WordbookDetailPage/WordbookDetailPage.tsx
+++ b/src/components/pages/WordbookDetailPage/WordbookDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useParams } from 'react-router-dom';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Word } from '@/domain/word';
 import { getWordList } from '@/apis/word';
 import type { AsyncState } from '@/shared/types/asyncState';
@@ -9,7 +9,7 @@ import { ROUTES } from '@/router/path';
 import { useModalStore } from '@/store/useModalStore';
 import type { Wordbook } from '@/domain/wordbook';
 import { useWordSelection } from '@/hooks/useWordSelection';
-import { getUserWordbookList } from '@/apis/wordbook';
+import { getUserWordbookList, createUserWordbook } from '@/apis/wordbook';
 
 export const WordbookDetailPage = () => {
   const navigate = useNavigate();
@@ -41,6 +41,15 @@ export const WordbookDetailPage = () => {
     setSelectedWordbook(null);
     clear();
   };
+
+  const fetchUserWordbooks = useCallback(async () => {
+    try {
+      const data = await getUserWordbookList();
+      setUserWordbooks({ status: 'success', data });
+    } catch (_) {
+      setUserWordbooks({ status: 'error' });
+    }
+  }, []);
 
   const handleNavigate = () => {
     const path = ROUTES.WORDBOOKS;
@@ -79,15 +88,20 @@ export const WordbookDetailPage = () => {
     selectModeClear();
   };
 
-  const handleWordbookCreateModalSubmit = () => {
+  const handleWordbookCreateModalSubmit = async () => {
     if (wordbookName.trim() === '') {
       alert('단어장 이름을 입력해주세요.');
       return;
     }
-    // TODO: 단어장 생성 API 연동 및 라우팅 로직 추가
-    alert(`단어장 "${wordbookName}"이(가) 생성되었습니다!`);
-    setWordbookName('');
-    close(wordbookCreateModalId);
+    try {
+      await createUserWordbook(wordbookName, null);
+      await fetchUserWordbooks(); // 생성 후 사용자 단어장 목록 갱신
+      setWordbookName('');
+      close(wordbookCreateModalId);
+    } catch (_) {
+      // TODO: 에러 발생 시 UI/UX 기획 필요
+      alert('단어장 생성 중에 오류가 발생했습니다.');
+    }
   };
 
   const handleWordbookCreateModalCancel = () => {
@@ -114,16 +128,8 @@ export const WordbookDetailPage = () => {
   }, [wordbookId]);
 
   useEffect(() => {
-    const fetchUserWordbooks = async () => {
-      try {
-        const data = await getUserWordbookList();
-        setUserWordbooks({ status: 'success', data });
-      } catch (_) {
-        setUserWordbooks({ status: 'error' });
-      }
-    };
     fetchUserWordbooks();
-  }, []);
+  }, [fetchUserWordbooks]);
 
   // page에서 모든 fetch data의 예외처리를 끝내고, template 이하는 완결된 데이터를 가정한다.
   // TODO: 로딩, 에러 UI/UX 기획 필요

--- a/src/mapper/wordbook.ts
+++ b/src/mapper/wordbook.ts
@@ -1,30 +1,25 @@
-import type { GetWordbookListResponse, GetWordbookResponse } from '@/apis/wordbook/types';
+import type { OrderedWordbookResponse, WordbookResponse } from '@/apis/wordbook/types';
 import type { Wordbook } from '@/domain/wordbook';
 
-type WordbookResponseItem = GetWordbookListResponse[number];
-
-export const mapWordbook = (item: WordbookResponseItem): Wordbook => {
+// 평탄한 단어장 응답 → 도메인
+export const mapWordbook = (res: WordbookResponse): Wordbook => {
   return {
-    id: item.wordbook.id,
-    title: item.wordbook.title,
-    description: item.wordbook.description ?? '',
-    type: item.wordbook.type,
+    id: res.id,
+    title: res.title,
+    description: res.description ?? '',
+    type: res.type,
   };
 };
 
-export const mapUserWordbook = (item: GetWordbookResponse): Wordbook => {
-  return {
-    id: item.id,
-    title: item.title,
-    description: item.description ?? '',
-    type: item.type,
-  };
+// order_index로 감싼 응답 → 도메인 (order_index는 정렬에만 쓰고 도메인에는 넣지 않음)
+export const mapOrderedWordbook = (res: OrderedWordbookResponse): Wordbook => {
+  return mapWordbook(res.wordbook);
 };
 
-export const mapWordbookList = (response: GetWordbookListResponse): Wordbook[] => {
-  return response.map(mapWordbook);
+export const mapWordbookList = (res: WordbookResponse[]): Wordbook[] => {
+  return res.map(mapWordbook);
 };
 
-export const mapUserWordbookList = (response: GetWordbookResponse[]): Wordbook[] => {
-  return response.map(mapUserWordbook);
+export const mapOrderedWordbookList = (res: OrderedWordbookResponse[]): Wordbook[] => {
+  return res.map(mapOrderedWordbook);
 };


### PR DESCRIPTION
## 🫧 요약

- 사용자 단어장 생성 api 연동

## ✅ 작업 내용

- 사용자 단어장 생성 api 연동
- order index 포함 여부에 따른 mapper naming 다듬기
- 재호출이 필요한 api 호출 함수를 useCallback 으로 refactoring

## 🧪 테스트 방법

- 시스템 단어장 상세 페이지 -> 케밥 메뉴 -> 나의 단어장에 단어 추가하기 버튼 클릭 -> + 버튼 클릭 -> 단어장 제목 입력 후 생성 버튼 클릭

## 📷 참고 자료 - 스크린샷 / 링크 / GIF / ...

<img width="355" height="756" alt="image" src="https://github.com/user-attachments/assets/c7720f1d-a573-4c79-a261-c88214e60b39" />

## ❣️ 관련 이슈

- close #81 

## ☝️ 참고 사항

- 참고하세요~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 단어장 생성 기능이 추가되어, 새 단어장을 만들고 목록에 바로 반영됩니다.
* **Bug Fixes**
  * 단어장 목록 조회 및 사용자 단어장 표시 방식이 개선되어 정렬된 결과와 상세 정보가 더 안정적으로 반영됩니다.
  * 생성 또는 조회 실패 시 오류 메시지가 표시되어 문제를 더 쉽게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->