### PR TITLE
[FEAT] 메인 페이지 사용자 단어장 목록 조회 API 연동

### DIFF
--- a/src/components/pages/WordbooksPage/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage/WordbooksPage.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@/router/path';
 import { getUserWordbookList, getWordbookList } from '@/apis/wordbook';
 import type { Wordbook } from '@/domain/wordbook';
-import { combineAsyncStates, type AsyncState } from '@/shared/types/asyncState';
+import { type AsyncState } from '@/shared/types/asyncState';
 import { WordbooksPageTemplate } from '@/components/templates/WordbooksPageTemplate/WordbooksPageTemplate';
 import { useModalStore } from '@/store/useModalStore';
 import { CreateWordbookModal } from '@/components/organisms/CreateWordbookModal/CreateWordbookModal';

--- a/src/components/pages/WordbooksPage/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage/WordbooksPage.tsx
@@ -24,8 +24,13 @@ export const WordbooksPage = () => {
   const open = useModalStore((s) => s.open);
   const close = useModalStore((s) => s.close);
 
-  const handleNavigate = (id: string) => {
-    const path = ROUTES.WORDBOOK_DETAIL.replace(':wordbookId', String(id));
+  const handleSystemWordbookNavigate = (id: string) => {
+    const path = ROUTES.WORDBOOK_DETAIL.replace(':wordbookId', id);
+    navigate(path);
+  };
+
+  const handleUserWordbookNavigate = (id: string) => {
+    const path = ROUTES.USER_WORDBOOK_DETAIL.replace(':wordbookId', id);
     navigate(path);
   };
 
@@ -110,17 +115,15 @@ export const WordbooksPage = () => {
 
   const [systemWordbooksData, userWordbooksData] = pageData.data;
 
+  const isCurriculumTab = tabs.find((tab) => tab.id === activeTab)?.label === '커리큘럼';
+
   return (
     <WordbooksPageTemplate
       tabs={tabs}
       activeTab={activeTab}
       handleTabClick={handleTabClick}
-      wordbooks={
-        tabs.find((tab) => tab.id === activeTab)?.label === '커리큘럼'
-          ? systemWordbooksData
-          : userWordbooksData
-      }
-      handleNavigate={handleNavigate}
+      wordbooks={isCurriculumTab ? systemWordbooksData : userWordbooksData}
+      handleNavigate={isCurriculumTab ? handleSystemWordbookNavigate : handleUserWordbookNavigate}
       createWordbookModalId={CREATE_WORDBOOK_MODAL_ID}
       onOpenWordbookCreateModal={() => open(CREATE_WORDBOOK_MODAL_ID)}
       onClose={resetCreateWordbookForm}

--- a/src/components/pages/WordbooksPage/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage/WordbooksPage.tsx
@@ -2,9 +2,9 @@ import { type Tab } from '@/components/organisms/TabSwitcher/TabSwitcher';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@/router/path';
-import { getWordbookList } from '@/apis/wordbook';
+import { getUserWordbookList, getWordbookList } from '@/apis/wordbook';
 import type { Wordbook } from '@/domain/wordbook';
-import type { AsyncState } from '@/shared/types/asyncState';
+import { combineAsyncStates, type AsyncState } from '@/shared/types/asyncState';
 import { WordbooksPageTemplate } from '@/components/templates/WordbooksPageTemplate/WordbooksPageTemplate';
 import { useModalStore } from '@/store/useModalStore';
 import { CreateWordbookModal } from '@/components/organisms/CreateWordbookModal/CreateWordbookModal';
@@ -13,6 +13,9 @@ export const WordbooksPage = () => {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<number>(1);
   const [systemWordbooks, setSystemWordbooks] = useState<AsyncState<Wordbook[]>>({
+    status: 'idle',
+  });
+  const [userWordbooks, setUserWordbooks] = useState<AsyncState<Wordbook[]>>({
     status: 'idle',
   });
 
@@ -39,6 +42,21 @@ export const WordbooksPage = () => {
       }
     };
     fetchSystemWordbookList();
+  }, []);
+
+  useEffect(() => {
+    const fetchUserWordbookList = async () => {
+      try {
+        setUserWordbooks({ status: 'loading' });
+        const data = await getUserWordbookList();
+        setUserWordbooks({ status: 'success', data: data });
+      } catch (_) {
+        // TODO : 에러 발생 시 UI/UX 기획 필요
+        setUserWordbooks({ status: 'error' });
+        alert('사용자 단어장 목록을 불러오는 데에 실패했습니다. 다시 시도해주세요.');
+      }
+    };
+    fetchUserWordbookList();
   }, []);
 
   const handleTabClick = (tab: Tab) => {
@@ -80,7 +98,9 @@ export const WordbooksPage = () => {
     );
   };
 
-  switch (systemWordbooks.status) {
+  const pageData = combineAsyncStates(systemWordbooks, userWordbooks);
+
+  switch (pageData.status) {
     case 'idle':
     case 'loading':
       return <div>Loading...</div>;
@@ -88,16 +108,18 @@ export const WordbooksPage = () => {
       return <div>오류가 발생했습니다. 다시 시도해주세요.</div>;
   }
 
+  const [systemWordbooksData, userWordbooksData] = pageData.data;
+
   return (
     <WordbooksPageTemplate
       tabs={tabs}
       activeTab={activeTab}
       handleTabClick={handleTabClick}
-      wordbooks={systemWordbooks.data.filter((wordbook) =>
+      wordbooks={
         tabs.find((tab) => tab.id === activeTab)?.label === '커리큘럼'
-          ? wordbook.type === 'SYSTEM'
-          : wordbook.type === 'USER',
-      )}
+          ? systemWordbooksData
+          : userWordbooksData
+      }
       handleNavigate={handleNavigate}
       createWordbookModalId={CREATE_WORDBOOK_MODAL_ID}
       onOpenWordbookCreateModal={() => open(CREATE_WORDBOOK_MODAL_ID)}

--- a/src/components/pages/WordbooksPage/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage/WordbooksPage.tsx
@@ -103,9 +103,10 @@ export const WordbooksPage = () => {
     );
   };
 
-  const pageData = combineAsyncStates(systemWordbooks, userWordbooks);
+  const isCurriculumTab = tabs.find((tab) => tab.id === activeTab)?.label === '커리큘럼';
+  const currentTabState = isCurriculumTab ? systemWordbooks : userWordbooks;
 
-  switch (pageData.status) {
+  switch (currentTabState.status) {
     case 'idle':
     case 'loading':
       return <div>Loading...</div>;
@@ -113,16 +114,14 @@ export const WordbooksPage = () => {
       return <div>오류가 발생했습니다. 다시 시도해주세요.</div>;
   }
 
-  const [systemWordbooksData, userWordbooksData] = pageData.data;
-
-  const isCurriculumTab = tabs.find((tab) => tab.id === activeTab)?.label === '커리큘럼';
+  const wordbooksData = currentTabState.data;
 
   return (
     <WordbooksPageTemplate
       tabs={tabs}
       activeTab={activeTab}
       handleTabClick={handleTabClick}
-      wordbooks={isCurriculumTab ? systemWordbooksData : userWordbooksData}
+      wordbooks={wordbooksData}
       handleNavigate={isCurriculumTab ? handleSystemWordbookNavigate : handleUserWordbookNavigate}
       createWordbookModalId={CREATE_WORDBOOK_MODAL_ID}
       onOpenWordbookCreateModal={() => open(CREATE_WORDBOOK_MODAL_ID)}

--- a/src/components/pages/WordbooksPage/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage/WordbooksPage.tsx
@@ -12,10 +12,12 @@ import { CreateWordbookModal } from '@/components/organisms/CreateWordbookModal/
 export const WordbooksPage = () => {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<number>(1);
-  const [wordbooks, setWordbooks] = useState<AsyncState<Wordbook[]>>({ status: 'idle' });
+  const [systemWordbooks, setSystemWordbooks] = useState<AsyncState<Wordbook[]>>({
+    status: 'idle',
+  });
 
-  // 단어장 생성 플로우 - 단어장 이름 상태 및 모달 open/close 핸들러
-  const [wordbookName, setWordbookName] = useState<string>('');
+  // 사용자 단어장 생성 플로우 - 단어장 이름 상태 및 모달 open/close 핸들러
+  const [userWordbookName, setUserWordbookName] = useState<string>('');
   const open = useModalStore((s) => s.open);
   const close = useModalStore((s) => s.close);
 
@@ -25,18 +27,18 @@ export const WordbooksPage = () => {
   };
 
   useEffect(() => {
-    async function fetchWordbookList() {
+    const fetchSystemWordbookList = async () => {
       try {
-        setWordbooks({ status: 'loading' });
+        setSystemWordbooks({ status: 'loading' });
         const data = await getWordbookList();
-        setWordbooks({ status: 'success', data: data });
+        setSystemWordbooks({ status: 'success', data: data });
       } catch (_) {
         // TODO : 에러 발생 시 UI/UX 기획 필요
-        setWordbooks({ status: 'error' });
+        setSystemWordbooks({ status: 'error' });
         alert('단어장 목록을 불러오는 데에 실패했습니다. 다시 시도해주세요.');
       }
-    }
-    fetchWordbookList();
+    };
+    fetchSystemWordbookList();
   }, []);
 
   const handleTabClick = (tab: Tab) => {
@@ -50,7 +52,7 @@ export const WordbooksPage = () => {
   const CREATE_WORDBOOK_MODAL_ID = 'create-wordbook-modal';
 
   const resetCreateWordbookForm = () => {
-    setWordbookName('');
+    setUserWordbookName('');
   };
 
   const handleCreateWordbookCancel = () => {
@@ -61,15 +63,15 @@ export const WordbooksPage = () => {
   const createWordbookModalContent = () => {
     return (
       <CreateWordbookModal
-        value={wordbookName}
-        onChange={setWordbookName}
+        value={userWordbookName}
+        onChange={setUserWordbookName}
         onSubmit={() => {
-          if (wordbookName.trim() === '') {
+          if (userWordbookName.trim() === '') {
             alert('단어장 이름을 입력해주세요.');
             return;
           }
           // TODO: 단어장 생성 API 연동 및 라우팅 로직 추가
-          alert(`단어장 "${wordbookName}"이(가) 생성되었습니다!`);
+          alert(`단어장 "${userWordbookName}"이(가) 생성되었습니다!`);
           resetCreateWordbookForm();
           close(CREATE_WORDBOOK_MODAL_ID);
         }}
@@ -78,7 +80,7 @@ export const WordbooksPage = () => {
     );
   };
 
-  switch (wordbooks.status) {
+  switch (systemWordbooks.status) {
     case 'idle':
     case 'loading':
       return <div>Loading...</div>;
@@ -91,7 +93,7 @@ export const WordbooksPage = () => {
       tabs={tabs}
       activeTab={activeTab}
       handleTabClick={handleTabClick}
-      wordbooks={wordbooks.data.filter((wordbook) =>
+      wordbooks={systemWordbooks.data.filter((wordbook) =>
         tabs.find((tab) => tab.id === activeTab)?.label === '커리큘럼'
           ? wordbook.type === 'SYSTEM'
           : wordbook.type === 'USER',


### PR DESCRIPTION
## 🫧 요약

- 사용자 단어장 목록 조회 API 연동

## ✅ 작업 내용

- WordbooksPage에서 userWordbooks 상태 추가
- 사용자 단어장으로 이동하는 navigate handler 추가

## 🧪 테스트 방법

- 내 단어장 tab 클릭 시 단어장 목록이 보이는지 확인
- 클릭 시 단어장 상세 조회로 navigate 되는지 확인 (단어 목록 연동은 아직 안 되었습니다)

## 📷 참고 자료 - 스크린샷 / 링크 / GIF / ...
<img width="442" height="358" alt="image" src="https://github.com/user-attachments/assets/5ff42184-1994-44c0-bc05-416fd3a96393" />

## ❣️ 관련 이슈

- close #83

## ☝️ 참고 사항

- 참고하세요~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기능 개선**
  * 단어장 화면에서 시스템 단어장과 사용자 단어장을 분리해 각각의 로딩/성공/오류 상태를 더 명확히 표시합니다.
  * 탭(커리큘럼 여부 포함) 전환에 따라 표시되는 목록과 상세 내비게이션이 선택된 탭 기준으로 동작하도록 개선했습니다.
  * 사용자 단어장 생성 모달의 입력 공백 검증, 생성 완료 알림 문구 반영, 생성 후 폼 초기화 및 모달 종료 흐름을 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->