### PR TITLE
[FEAT] 사용자 단어장 내 단어 목록 조회 API 연동

### DIFF
--- a/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
+++ b/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
@@ -125,7 +125,7 @@ export const UserWordbookDetailPage = () => {
   const handleCreateWordSubmit = () => {
     setWords((prev) => {
       if (prev.status !== 'success') {
-        return { status: 'success', data: [newWord] };
+        return prev;
       }
 
       return { status: 'success', data: [...prev.data, newWord] };

--- a/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
+++ b/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
@@ -1,9 +1,11 @@
 import type { PartOfSpeech, Word } from '@/domain/word';
 import { useModalStore } from '@/store/useModalStore';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { UserWordbookDetailPageTemplate } from '@/components/templates/UserWordbookDetailPageTemplate/UserWordbookDetailPageTemplate';
 import { ROUTES } from '@/router/path';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
+import type { AsyncState } from '@/shared/types/asyncState';
+import { getWordList } from '@/apis/word';
 
 export const UserWordbookDetailPage = () => {
   const navigate = useNavigate();
@@ -17,8 +19,9 @@ export const UserWordbookDetailPage = () => {
       },
     ],
   });
-  const [words, setWords] = useState<Word[]>([]);
+  const [words, setWords] = useState<AsyncState<Word[]>>({ status: 'idle' });
   const [newWord, setNewWord] = useState<Word>(createEmptyWord());
+  const { wordbookId } = useParams<{ wordbookId: string }>();
 
   // Header kebab menu
   const [isKebabMenuOpen, setIsKebabMenuOpen] = useState<boolean>(false);
@@ -30,6 +33,21 @@ export const UserWordbookDetailPage = () => {
   const isCreateWordValid =
     newWord.textEn.trim() !== '' &&
     newWord.meanings.every((meaning) => meaning.textKo.trim() !== '');
+
+  useEffect(() => {
+    if (!wordbookId) return;
+
+    const fetchWords = async () => {
+      try {
+        setWords({ status: 'loading' });
+        const data = await getWordList(wordbookId);
+        setWords({ status: 'success', data });
+      } catch (_) {
+        setWords({ status: 'error' });
+      }
+    };
+    fetchWords();
+  }, [wordbookId]);
 
   const handleKebabMenuOpen = (flag: boolean) => {
     if (flag) setIsKebabMenuOpen(true);
@@ -105,7 +123,13 @@ export const UserWordbookDetailPage = () => {
   };
 
   const handleCreateWordSubmit = () => {
-    setWords((prev) => [...prev, newWord]);
+    setWords((prev) => {
+      if (prev.status !== 'success') {
+        return { status: 'success', data: [newWord] };
+      }
+
+      return { status: 'success', data: [...prev.data, newWord] };
+    });
 
     resetCreateWordForm();
     closeCreateWordModal(CREATE_WORD_MODAL_ID);
@@ -125,9 +149,18 @@ export const UserWordbookDetailPage = () => {
     const path = ROUTES.WORDBOOKS; // TODO: '나의 단어장' 탭이 보여야 하는지 확인 필요
     navigate(path);
   };
+
+  switch (words.status) {
+    case 'idle':
+    case 'loading':
+      return <div>Loading...</div>;
+    case 'error':
+      return <div>오류가 발생했습니다. 다시 시도해주세요.</div>;
+  }
+
   return (
     <UserWordbookDetailPageTemplate
-      words={words}
+      words={words.data}
       // kebab menu props
       isKebabMenuOpen={isKebabMenuOpen}
       handleKebabMenuOpen={handleKebabMenuOpen}


### PR DESCRIPTION
## 🫧 요약

- 사용자 단어장 내 단어 목록 조회 API 연동

## ✅ 작업 내용

- 기존 단어 목록 상태에 AsyncState 추가
- 로딩 및 에러 처리 추가
- 단어 목록 조회 API 연동
  - 백엔드에서 타입 변환 과정 오류가 있어 dev 배포 먼저 하고 수정 사항 올렸습니다. 백엔드 PR도 확인 부탁드립니다.

## 🧪 테스트 방법

- `http://localhost:5173/user/wordbook/단어장 id/wordbook-detail` 단어 목록 조회 확인

## 📷 참고 자료 - 스크린샷 / 링크 / GIF / ...
<img width="442" height="270" alt="image" src="https://github.com/user-attachments/assets/3c5fd760-f478-436f-811d-788b4f3d8ba5" />

## ❣️ 관련 이슈

- close #85

## ☝️ 참고 사항

- 참고하세요~
