### PR TITLE
[FEAT] 메인 페이지 사용자 단어장 생성 API 연동

### DIFF
--- a/src/components/organisms/CreateWordbookModal/CreateWordbookModal.tsx
+++ b/src/components/organisms/CreateWordbookModal/CreateWordbookModal.tsx
@@ -6,6 +6,7 @@ export interface CreateWordbookModalProps {
   onChange: (v: string) => void;
   onSubmit: () => void;
   onCancel: () => void;
+  isSubmitting?: boolean;
 }
 
 export const CreateWordbookModal = ({
@@ -13,13 +14,18 @@ export const CreateWordbookModal = ({
   onChange,
   onSubmit,
   onCancel,
+  isSubmitting = false,
 }: CreateWordbookModalProps) => {
   return (
     <div className="flex flex-col gap-[0.5rem]">
       <h2 className="text-lg">단어장 이름을 정해주세요</h2>
       <Input value={value} onChange={(e) => onChange(e.target.value)} />
       <div className="flex justify-center gap-[0.5rem]">
-        <Button content="생성" variant="primary" onClick={onSubmit} />
+        <Button
+          content={isSubmitting ? '생성 중' : '생성'}
+          variant={isSubmitting ? 'disabled' : 'primary'}
+          onClick={onSubmit}
+        />
         <Button content="취소" variant="secondary" onClick={onCancel} />
       </div>
     </div>

--- a/src/components/pages/WordbooksPage/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage/WordbooksPage.tsx
@@ -97,16 +97,14 @@ export const WordbooksPage = () => {
     }
 
     alert(`단어장 "${userWordbookName}"이(가) 생성되었습니다!`);
+    resetCreateWordbookForm();
+    close(CREATE_WORDBOOK_MODAL_ID);
 
     try {
       await fetchUserWordbookList();
     } catch {
       alert('단어장 목록을 불러오는 데에 실패했습니다. 다시 시도해주세요.');
-      return;
     }
-
-    resetCreateWordbookForm();
-    close(CREATE_WORDBOOK_MODAL_ID);
   };
 
   const handleCreateWordbookCancel = () => {

--- a/src/components/pages/WordbooksPage/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage/WordbooksPage.tsx
@@ -84,19 +84,23 @@ export const WordbooksPage = () => {
   };
 
   const handleCreateWordbookSubmit = async () => {
-    if (userWordbookName.trim() === '') {
+    if (isCreateWordbookSubmitting) return;
+
+    const trimmedUserWordbookName = userWordbookName.trim();
+
+    if (trimmedUserWordbookName === '') {
       alert('단어장 이름을 입력해주세요.');
       return;
     }
     // TODO: 에러 발생 시 UI/UX 기획 필요
     try {
-      await createUserWordbook(userWordbookName, null);
+      await createUserWordbook(trimmedUserWordbookName, null);
     } catch {
       alert('단어장 생성 중 오류가 발생했습니다. 다시 시도해주세요.');
       return;
     }
 
-    alert(`단어장 "${userWordbookName}"이(가) 생성되었습니다!`);
+    alert(`단어장 "${trimmedUserWordbookName}"이(가) 생성되었습니다!`);
     resetCreateWordbookForm();
     close(CREATE_WORDBOOK_MODAL_ID);
 

--- a/src/components/pages/WordbooksPage/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage/WordbooksPage.tsx
@@ -21,6 +21,7 @@ export const WordbooksPage = () => {
 
   // 사용자 단어장 생성 플로우 - 단어장 이름 상태 및 모달 open/close 핸들러
   const [userWordbookName, setUserWordbookName] = useState<string>('');
+  const [isCreateWordbookSubmitting, setIsCreateWordbookSubmitting] = useState<boolean>(false);
   const open = useModalStore((s) => s.open);
   const close = useModalStore((s) => s.close);
 
@@ -92,11 +93,15 @@ export const WordbooksPage = () => {
       alert('단어장 이름을 입력해주세요.');
       return;
     }
+
+    setIsCreateWordbookSubmitting(true);
+
     // TODO: 에러 발생 시 UI/UX 기획 필요
     try {
       await createUserWordbook(trimmedUserWordbookName, null);
     } catch {
       alert('단어장 생성 중 오류가 발생했습니다. 다시 시도해주세요.');
+      setIsCreateWordbookSubmitting(false);
       return;
     }
 
@@ -108,6 +113,8 @@ export const WordbooksPage = () => {
       await fetchUserWordbookList();
     } catch {
       alert('단어장 목록을 불러오는 데에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setIsCreateWordbookSubmitting(false);
     }
   };
 
@@ -123,6 +130,7 @@ export const WordbooksPage = () => {
         onChange={setUserWordbookName}
         onSubmit={handleCreateWordbookSubmit}
         onCancel={handleCreateWordbookCancel}
+        isSubmitting={isCreateWordbookSubmitting}
       />
     );
   };

--- a/src/components/pages/WordbooksPage/WordbooksPage.tsx
+++ b/src/components/pages/WordbooksPage/WordbooksPage.tsx
@@ -1,8 +1,8 @@
 import { type Tab } from '@/components/organisms/TabSwitcher/TabSwitcher';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@/router/path';
-import { getUserWordbookList, getWordbookList } from '@/apis/wordbook';
+import { createUserWordbook, getUserWordbookList, getWordbookList } from '@/apis/wordbook';
 import type { Wordbook } from '@/domain/wordbook';
 import { type AsyncState } from '@/shared/types/asyncState';
 import { WordbooksPageTemplate } from '@/components/templates/WordbooksPageTemplate/WordbooksPageTemplate';
@@ -49,20 +49,25 @@ export const WordbooksPage = () => {
     fetchSystemWordbookList();
   }, []);
 
-  useEffect(() => {
-    const fetchUserWordbookList = async () => {
-      try {
-        setUserWordbooks({ status: 'loading' });
-        const data = await getUserWordbookList();
-        setUserWordbooks({ status: 'success', data: data });
-      } catch (_) {
-        // TODO : 에러 발생 시 UI/UX 기획 필요
-        setUserWordbooks({ status: 'error' });
-        alert('사용자 단어장 목록을 불러오는 데에 실패했습니다. 다시 시도해주세요.');
-      }
-    };
-    fetchUserWordbookList();
+  const fetchUserWordbookList = useCallback(async () => {
+    try {
+      setUserWordbooks({ status: 'loading' });
+      const data = await getUserWordbookList();
+      setUserWordbooks({ status: 'success', data: data });
+    } catch (error) {
+      // TODO : 에러 발생 시 UI/UX 기획 필요
+      // 호출부에서 alert 처리하기 위해 에러 throw만 수행
+      setUserWordbooks({ status: 'error' });
+      throw error;
+    }
   }, []);
+
+  useEffect(() => {
+    fetchUserWordbookList().catch(() => {
+      // TODO : 에러 발생 시 UI/UX 기획 필요
+      alert('단어장 목록을 불러오는 데에 실패했습니다. 다시 시도해주세요.');
+    });
+  }, [fetchUserWordbookList]);
 
   const handleTabClick = (tab: Tab) => {
     if (tab.disabled) {
@@ -78,6 +83,32 @@ export const WordbooksPage = () => {
     setUserWordbookName('');
   };
 
+  const handleCreateWordbookSubmit = async () => {
+    if (userWordbookName.trim() === '') {
+      alert('단어장 이름을 입력해주세요.');
+      return;
+    }
+    // TODO: 에러 발생 시 UI/UX 기획 필요
+    try {
+      await createUserWordbook(userWordbookName, null);
+    } catch {
+      alert('단어장 생성 중 오류가 발생했습니다. 다시 시도해주세요.');
+      return;
+    }
+
+    alert(`단어장 "${userWordbookName}"이(가) 생성되었습니다!`);
+
+    try {
+      await fetchUserWordbookList();
+    } catch {
+      alert('단어장 목록을 불러오는 데에 실패했습니다. 다시 시도해주세요.');
+      return;
+    }
+
+    resetCreateWordbookForm();
+    close(CREATE_WORDBOOK_MODAL_ID);
+  };
+
   const handleCreateWordbookCancel = () => {
     resetCreateWordbookForm();
     close(CREATE_WORDBOOK_MODAL_ID);
@@ -88,16 +119,7 @@ export const WordbooksPage = () => {
       <CreateWordbookModal
         value={userWordbookName}
         onChange={setUserWordbookName}
-        onSubmit={() => {
-          if (userWordbookName.trim() === '') {
-            alert('단어장 이름을 입력해주세요.');
-            return;
-          }
-          // TODO: 단어장 생성 API 연동 및 라우팅 로직 추가
-          alert(`단어장 "${userWordbookName}"이(가) 생성되었습니다!`);
-          resetCreateWordbookForm();
-          close(CREATE_WORDBOOK_MODAL_ID);
-        }}
+        onSubmit={handleCreateWordbookSubmit}
         onCancel={handleCreateWordbookCancel}
       />
     );


### PR DESCRIPTION
## 🫧 요약

- 메인 페이지 사용자 단어장 생성 API 연동

## ✅ 작업 내용

- 사용자 단어장 목록 fetch 함수를 useCallback으로 감쌌습니다.
  - .1) 처음 페이지 진입 시, 2) 사용자 단어장 생성 후 함수가 호출되는데, 1)의 의존성 배열에 fetch 함수가 들어가므로 재생성 방지를 위함
- 사용자 단어장 생성 핸들러에서 create와 fetch 함수가 실행되는데, 각각의 예외 처리를 위해 함수 선언부에서는 error를 던지고, 호출부에서 alert 처리했습니다.

## 🧪 테스트 방법

- 내 단어장 > + 버튼 클릭 후 단어장 생성 > 단어장 생성 완료 alert가 뜨고 단어장 목록이 refetch되는지 확인

## 📷 참고 자료 - 스크린샷 / 링크 / GIF / ...

## ❣️ 관련 이슈

- close #84 

## ☝️ 참고 사항

- 참고하세요~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 단어장 목록을 불러오거나 새로고침할 때 오류가 발생하면 사용자에게 안내하도록 개선했습니다.
  * 단어장 생성 시 이름이 비어 있거나 공백만 입력된 경우 제출되지 않습니다.
  * 생성 요청 중 중복 제출을 방지합니다.
  * 생성 진행 상태를 버튼에 표시하고, 완료 후 입력 폼을 초기화하며 목록을 자동으로 갱신합니다.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->