### PR TITLE
[FEAT] 사용자 단어 추가 api 연동

### DIFF
--- a/src/apis/word/index.ts
+++ b/src/apis/word/index.ts
@@ -1,7 +1,12 @@
 import { api } from '@/apis/axiosInstance';
 import type { Word } from '@/domain/word';
 import type { WordResponse } from '@/apis/word/types';
-import { mapWordListResponseToDomain } from '@/mapper/word';
+import {
+  mapWordDomainToCreateRequest,
+  mapWordListResponseToDomain,
+  mapWordResponseToDomain,
+  type CreateUserWordSource,
+} from '@/mapper/word';
 
 export const getWordList = async (wordbookId: string): Promise<Word[]> => {
   try {
@@ -9,6 +14,20 @@ export const getWordList = async (wordbookId: string): Promise<Word[]> => {
     return mapWordListResponseToDomain(res.data);
   } catch (error) {
     console.error('[ERROR] 단어 목록 조회 실패', error);
+    throw error;
+  }
+};
+
+export const createUserWord = async (
+  wordbookId: string,
+  word: CreateUserWordSource,
+): Promise<Word> => {
+  try {
+    const body = mapWordDomainToCreateRequest(word);
+    const res = await api.post<WordResponse>(`/wordbooks/${wordbookId}/words/user`, body);
+    return mapWordResponseToDomain(res.data);
+  } catch (error) {
+    console.error('[ERROR] 단어 생성 실패', error);
     throw error;
   }
 };

--- a/src/apis/word/types.ts
+++ b/src/apis/word/types.ts
@@ -18,3 +18,11 @@ export type PartOfSpeechResponse =
   | 'PREPOSITION'
   | 'CONJUNCTION'
   | 'INTERJECTION';
+
+export interface CreateUserWordRequest {
+  enText: string;
+  meanings: {
+    partOfSpeech: PartOfSpeechResponse;
+    meaning: string;
+  }[];
+}

--- a/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
+++ b/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
@@ -6,7 +6,6 @@ import { ROUTES } from '@/router/path';
 import { useNavigate, useParams } from 'react-router-dom';
 import type { AsyncState } from '@/shared/types/asyncState';
 import { createUserWord, getWordList } from '@/apis/word';
-import { mapWordDomainToCreateRequest, mapWordResponseToDomain } from '@/mapper/word';
 
 export const UserWordbookDetailPage = () => {
   const navigate = useNavigate();

--- a/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
+++ b/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
@@ -5,7 +5,8 @@ import { UserWordbookDetailPageTemplate } from '@/components/templates/UserWordb
 import { ROUTES } from '@/router/path';
 import { useNavigate, useParams } from 'react-router-dom';
 import type { AsyncState } from '@/shared/types/asyncState';
-import { getWordList } from '@/apis/word';
+import { createUserWord, getWordList } from '@/apis/word';
+import { mapWordDomainToCreateRequest, mapWordResponseToDomain } from '@/mapper/word';
 
 export const UserWordbookDetailPage = () => {
   const navigate = useNavigate();
@@ -122,14 +123,24 @@ export const UserWordbookDetailPage = () => {
     setNewWord(createEmptyWord());
   };
 
-  const handleCreateWordSubmit = () => {
-    setWords((prev) => {
-      if (prev.status !== 'success') {
-        return prev;
-      }
+  const handleCreateWordSubmit = async () => {
+    if (!wordbookId || !isCreateWordValid) return;
 
-      return { status: 'success', data: [...prev.data, newWord] };
-    });
+    try {
+      const createdWord = await createUserWord(wordbookId, newWord);
+      alert('단어 생성에 성공했습니다.');
+
+      setWords((prev) => {
+        if (prev.status !== 'success') {
+          return prev;
+        }
+
+        return { status: 'success', data: [...prev.data, createdWord] };
+      });
+    } catch (_) {
+      // TODO: 에러 UI/UX 기획 필요
+      alert('단어 생성에 실패했습니다. 다시 시도해주세요.');
+    }
 
     resetCreateWordForm();
     closeCreateWordModal(CREATE_WORD_MODAL_ID);

--- a/src/mapper/word.ts
+++ b/src/mapper/word.ts
@@ -1,5 +1,7 @@
-import type { PartOfSpeechResponse, WordResponse } from '@/apis/word/types';
+import type { CreateUserWordRequest, PartOfSpeechResponse, WordResponse } from '@/apis/word/types';
 import type { Word, Meaning, PartOfSpeech } from '@/domain/word';
+
+export type CreateUserWordSource = Pick<Word, 'textEn' | 'meanings'>;
 
 export const mapWordResponseToDomain = (data: WordResponse): Word => {
   return {
@@ -18,6 +20,16 @@ export const mapWordListResponseToDomain = (data: WordResponse[]): Word[] => {
   return data.map(mapWordResponseToDomain);
 };
 
+export const mapWordDomainToCreateRequest = (
+  data: CreateUserWordSource,
+): CreateUserWordRequest => ({
+  enText: data.textEn,
+  meanings: data.meanings.map((meaning) => ({
+    partOfSpeech: POS_DOMAIN_RESPONSE_MAP[meaning.partOfSpeech],
+    meaning: meaning.textKo,
+  })),
+});
+
 export type PartOfSpeechLabel = 'n' | 'pron' | 'v' | 'adj' | 'adv' | 'prep' | 'conj' | 'interj';
 
 export const POS_RESPONSE_DOMAIN_MAP: Record<PartOfSpeechResponse, PartOfSpeech> = {
@@ -29,6 +41,17 @@ export const POS_RESPONSE_DOMAIN_MAP: Record<PartOfSpeechResponse, PartOfSpeech>
   PREPOSITION: 'preposition',
   CONJUNCTION: 'conjunction',
   INTERJECTION: 'interjection',
+};
+
+export const POS_DOMAIN_RESPONSE_MAP: Record<PartOfSpeech, PartOfSpeechResponse> = {
+  noun: 'NOUN',
+  pronoun: 'PRONOUN',
+  verb: 'VERB',
+  adjective: 'ADJECTIVE',
+  adverb: 'ADVERB',
+  preposition: 'PREPOSITION',
+  conjunction: 'CONJUNCTION',
+  interjection: 'INTERJECTION',
 };
 
 export const POS_DOMAIN_LABEL_MAP: Record<PartOfSpeech, PartOfSpeechLabel> = {


### PR DESCRIPTION
## 🫧 요약

- 사용자 단어 추가 api 연동

## ✅ 작업 내용

- 사용자 단어 추가 request 인터페이스 정의 (도메인 타입 사용)
- request 도메인 타입 -> dto 타입 매퍼 정의
- api 함수 정의 및 연동
  - UI에 생성된 응답을 바로 단어 배열에 추가하여 네트워크 비용 절감

## 🧪 테스트 방법

- 나의 단어장 > 단어 생성하기 > "단어 생성이 완료되었습니다." 모달 확인 > 새로운 단어가 단어 목록에 추가되었는지 확인

## 📷 참고 자료 - 스크린샷 / 링크 / GIF / ...

## ❣️ 관련 이슈

- close #88

## ☝️ 참고 사항

- 참고하세요~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 사용자 단어장에 새 단어를 전송해 서버에 저장하고, 저장된 결과를 단어 목록에 반영합니다.
* **버그 수정**
  * 단어 생성 시 단어장 ID가 없거나 입력이 유효하지 않으면 요청을 보내지 않습니다.
  * 저장 성공/실패에 대한 알림을 제공하고, 오류 발생 시 처리 후 원인 정보를 기록합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->