### PR TITLE
[FEAT] 사용자 단어장에 시스템 단어 추가 API 연동

### DIFF
--- a/src/apis/word/index.ts
+++ b/src/apis/word/index.ts
@@ -1,7 +1,7 @@
 import { api } from '@/apis/axiosInstance';
 import type { Word } from '@/domain/word';
 import type { WordResponse } from '@/apis/word/types';
-import { mapWordListResponseToDomain } from '@/mapper/word';
+import { mapWordListResponseToDomain, mapWordResponseToDomain } from '@/mapper/word';
 
 export const getWordList = async (wordbookId: string): Promise<Word[]> => {
   try {
@@ -9,6 +9,36 @@ export const getWordList = async (wordbookId: string): Promise<Word[]> => {
     return mapWordListResponseToDomain(res.data);
   } catch (error) {
     console.error('[ERROR] 단어 목록 조회 실패', error);
+    throw error;
+  }
+};
+
+export const addSystemWordToUserWordbook = async (
+  wordbookId: string,
+  systemWordId: string,
+): Promise<Word> => {
+  try {
+    const res = await api.post<WordResponse>(`/wordbooks/${wordbookId}/words/system`, {
+      systemWordId: systemWordId,
+    });
+    return mapWordResponseToDomain(res.data);
+  } catch (error) {
+    console.error('[ERROR] 단어 추가 실패', error);
+    throw error;
+  }
+};
+
+export const addSystemWordsToUserWordbook = async (
+  wordbookId: string,
+  systemWordIds: string[],
+): Promise<Word[]> => {
+  try {
+    const res = await api.post<WordResponse[]>(`/wordbooks/${wordbookId}/words/system/bulk`, {
+      systemWordIds: systemWordIds,
+    });
+    return mapWordListResponseToDomain(res.data);
+  } catch (error) {
+    console.error('[ERROR] 단어 일괄 추가 실패', error);
     throw error;
   }
 };

--- a/src/apis/word/index.ts
+++ b/src/apis/word/index.ts
@@ -28,7 +28,7 @@ export const addSystemWordToUserWordbook = async (
   }
 };
 
-export const addSystemWordsToUserWordbook = async (
+export const addSystemWordListToUserWordbook = async (
   wordbookId: string,
   systemWordIds: string[],
 ): Promise<Word[]> => {

--- a/src/apis/word/index.ts
+++ b/src/apis/word/index.ts
@@ -13,20 +13,20 @@ export const getWordList = async (wordbookId: string): Promise<Word[]> => {
   }
 };
 
-export const addSystemWordToUserWordbook = async (
-  wordbookId: string,
-  systemWordId: string,
-): Promise<Word> => {
-  try {
-    const res = await api.post<WordResponse>(`/wordbooks/${wordbookId}/words/system`, {
-      systemWordId: systemWordId,
-    });
-    return mapWordResponseToDomain(res.data);
-  } catch (error) {
-    console.error('[ERROR] 단어 추가 실패', error);
-    throw error;
-  }
-};
+// export const addSystemWordToUserWordbook = async (
+//   wordbookId: string,
+//   systemWordId: string,
+// ): Promise<Word> => {
+//   try {
+//     const res = await api.post<WordResponse>(`/wordbooks/${wordbookId}/words/system`, {
+//       systemWordId: systemWordId,
+//     });
+//     return mapWordResponseToDomain(res.data);
+//   } catch (error) {
+//     console.error('[ERROR] 단어 추가 실패', error);
+//     throw error;
+//   }
+// };
 
 export const addSystemWordListToUserWordbook = async (
   wordbookId: string,

--- a/src/components/pages/WordbookDetailPage/WordbookDetailPage.tsx
+++ b/src/components/pages/WordbookDetailPage/WordbookDetailPage.tsx
@@ -80,9 +80,17 @@ export const WordbookDetailPage = () => {
 
     try {
       const added = await addSystemWordsToUserWordbook(selectedWordbook.id, [...selectedIds]);
-      const skipped = selectedIds.size - added.length;
-      if (skipped > 0) {
-        alert(`${added.length}개의 단어를 추가했습니다. (${skipped}개는 이미 있는 단어라 제외)`);
+
+      // 응답(실제 추가된 단어)에 없는 선택 단어 = 중복으로 제외된 단어
+      const normalize = (text: string) => text.trim().toLowerCase();
+      const addedTexts = new Set(added.map((word) => normalize(word.textEn)));
+      const selectedWords =
+        words.status === 'success' ? words.data.filter((word) => selectedIds.has(word.id)) : [];
+      const skippedWords = selectedWords.filter((word) => !addedTexts.has(normalize(word.textEn)));
+
+      if (skippedWords.length > 0) {
+        const skippedNames = skippedWords.map((word) => word.textEn).join(', ');
+        alert(`${added.length}개의 단어를 추가했습니다.\n이미 있어서 제외된 단어: ${skippedNames}`);
       } else {
         alert(`${added.length}개의 단어를 추가했습니다.`);
       }

--- a/src/components/pages/WordbookDetailPage/WordbookDetailPage.tsx
+++ b/src/components/pages/WordbookDetailPage/WordbookDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Word } from '@/domain/word';
-import { getWordList, addSystemWordsToUserWordbook } from '@/apis/word';
+import { getWordList, addSystemWordListToUserWordbook } from '@/apis/word';
 import type { AsyncState } from '@/shared/types/asyncState';
 import { combineAsyncStates } from '@/shared/types/asyncState';
 import { WordbookDetailPageTemplate } from '@/components/templates/WordbookDetailPageTemplate/WordbookDetailPageTemplate';
@@ -79,7 +79,7 @@ export const WordbookDetailPage = () => {
     }
 
     try {
-      const added = await addSystemWordsToUserWordbook(selectedWordbook.id, [...selectedIds]);
+      const added = await addSystemWordListToUserWordbook(selectedWordbook.id, [...selectedIds]);
 
       // 응답(실제 추가된 단어)에 없는 선택 단어 = 중복으로 제외된 단어
       const normalize = (text: string) => text.trim().toLowerCase();

--- a/src/components/pages/WordbookDetailPage/WordbookDetailPage.tsx
+++ b/src/components/pages/WordbookDetailPage/WordbookDetailPage.tsx
@@ -80,7 +80,12 @@ export const WordbookDetailPage = () => {
 
     try {
       const added = await addSystemWordsToUserWordbook(selectedWordbook.id, [...selectedIds]);
-      alert(`${added.length}개의 단어를 추가했습니다.`);
+      const skipped = selectedIds.size - added.length;
+      if (skipped > 0) {
+        alert(`${added.length}개의 단어를 추가했습니다. (${skipped}개는 이미 있는 단어라 제외)`);
+      } else {
+        alert(`${added.length}개의 단어를 추가했습니다.`);
+      }
       selectModeClear();
     } catch (_) {
       // TODO: 에러 발생 시 UI/UX 기획 필요

--- a/src/components/pages/WordbookDetailPage/WordbookDetailPage.tsx
+++ b/src/components/pages/WordbookDetailPage/WordbookDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Word } from '@/domain/word';
-import { getWordList } from '@/apis/word';
+import { getWordList, addSystemWordsToUserWordbook } from '@/apis/word';
 import type { AsyncState } from '@/shared/types/asyncState';
 import { combineAsyncStates } from '@/shared/types/asyncState';
 import { WordbookDetailPageTemplate } from '@/components/templates/WordbookDetailPageTemplate/WordbookDetailPageTemplate';
@@ -68,7 +68,7 @@ export const WordbookDetailPage = () => {
     close(wordbookSelectModalId);
   };
 
-  const handleWordsAdditionConfirm = () => {
+  const handleWordsAdditionConfirm = async () => {
     if (!selectedWordbook) {
       alert('단어장을 선택해주세요.');
       return;
@@ -78,10 +78,14 @@ export const WordbookDetailPage = () => {
       return;
     }
 
-    // POST /wordbooks/:wordbookId/words/system api 요청
-    alert('POST /wordbooks/:wordbookId/words/system api 요청');
-
-    selectModeClear();
+    try {
+      const added = await addSystemWordsToUserWordbook(selectedWordbook.id, [...selectedIds]);
+      alert(`${added.length}개의 단어를 추가했습니다.`);
+      selectModeClear();
+    } catch (_) {
+      // TODO: 에러 발생 시 UI/UX 기획 필요
+      alert('단어 추가 중에 오류가 발생했습니다.');
+    }
   };
 
   const handleWordsAdditionCancel = () => {


### PR DESCRIPTION
## 🫧 요약

- 사용자 단어장에 시스템 단어 추가 API 연동

## ✅ 작업 내용

- 사용자 단어장에 시스템 단어 추가 API 연동

## 🧪 테스트 방법

- ex) console.log
- ex2) .env

## 📷 참고 자료 - 스크린샷 / 링크 / GIF / ...
<img width="814" height="767" alt="image" src="https://github.com/user-attachments/assets/f9dcabcc-70f4-442e-afce-1562643c75ba" />

## ❣️ 관련 이슈

- close #92 

## ☝️ 참고 사항

- 참고하세요~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 시스템 단어를 워드북에 하나 또는 여러 개 추가할 수 있습니다.
  * 단어 추가 결과를 안내하고, 이미 등록된 중복 단어를 별도로 알려줍니다.

* **버그 수정**
  * 단어 추가 완료 및 실패 시 선택 모드가 안정적으로 처리됩니다.
  * 단어 추가 실패 시 사용자에게 오류 알림을 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->