### PR TITLE
[FEAT] 사용자 단어 목록 삭제 API 연동

### DIFF
--- a/src/apis/word/index.ts
+++ b/src/apis/word/index.ts
@@ -61,3 +61,34 @@ export const createUserWord = async (
     throw error;
   }
 };
+
+// export const deleteUserWord = async (wordbookId: string, wordId: string): Promise<void> => {
+//   const body = { wordId };
+//   try {
+//     const res = await api.delete<void>(`/wordbooks/${wordbookId}/words/user`, {
+//       data: body,
+//     });
+//   } catch (error) {
+//     console.error('[ERROR] 단어 삭제 실패', error);
+//     throw error;
+//   }
+// };
+
+export const deleteUserWordList = async (
+  wordbookId: string,
+  wordIds: string[],
+): Promise<{ wordIds: string[] }> => {
+  const body = { wordIds };
+  try {
+    const res = await api.delete<{ wordIds: string[] }>(
+      `/wordbooks/${wordbookId}/words/user/bulk`,
+      {
+        data: body,
+      },
+    );
+    return res.data;
+  } catch (error) {
+    console.error('[ERROR] 단어 일괄 삭제 실패', error);
+    throw error;
+  }
+};

--- a/src/components/organisms/SelectModeDashboard/SelectModeDashboard.tsx
+++ b/src/components/organisms/SelectModeDashboard/SelectModeDashboard.tsx
@@ -1,9 +1,10 @@
 import type { Word } from '@/domain/word';
-import type { Wordbook } from '@/domain/wordbook';
 
 type Props = {
   words: Word[];
-  selectedWordbook: Wordbook;
+  title: string;
+  statusText: string;
+  confirmLabel?: string;
   selectedIds: Set<string>;
   onAllSelect: () => Promise<void> | void;
   onConfirm: () => Promise<void> | void;
@@ -12,7 +13,9 @@ type Props = {
 
 export const SelectModeDashboard = ({
   words,
-  selectedWordbook,
+  title,
+  statusText,
+  confirmLabel = '확인',
   selectedIds,
   onAllSelect,
   onConfirm,
@@ -23,13 +26,19 @@ export const SelectModeDashboard = ({
       <div className="flex w-full flex-col items-center justify-between gap-4 px-5 py-4">
         {/* 진행 상황 섹션 */}
         <ProgressSection
-          title={selectedWordbook.title}
+          title={title}
+          statusText={statusText}
           selectedNum={selectedIds.size}
           totalNum={words.length}
         />
 
         {/* 액션 버튼 섹션 */}
-        <ActionSection onAllSelect={onAllSelect} onConfirm={onConfirm} onCancel={onCancel} />
+        <ActionSection
+          confirmLabel={confirmLabel}
+          onAllSelect={onAllSelect}
+          onConfirm={onConfirm}
+          onCancel={onCancel}
+        />
       </div>
     </div>
   );
@@ -37,15 +46,16 @@ export const SelectModeDashboard = ({
 
 type ProgressSectionProps = {
   title: string;
+  statusText: string;
   selectedNum: number;
   totalNum: number;
 };
 
-const ProgressSection = ({ title, selectedNum, totalNum }: ProgressSectionProps) => {
+const ProgressSection = ({ title, statusText, selectedNum, totalNum }: ProgressSectionProps) => {
   return (
     <div className="flex w-full items-center justify-between text-gray-700">
       <div className="font-bold">
-        {title} <span className="text-sm font-normal">에 추가 중</span>
+        {title} <span className="text-sm font-normal">{statusText}</span>
       </div>
       <div>
         {selectedNum}/{totalNum}
@@ -55,17 +65,18 @@ const ProgressSection = ({ title, selectedNum, totalNum }: ProgressSectionProps)
 };
 
 type ActionSectionProps = {
+  confirmLabel: string;
   onAllSelect: () => Promise<void> | void;
   onConfirm: () => Promise<void> | void;
   onCancel: () => Promise<void> | void;
 };
 
-const ActionSection = ({ onAllSelect, onConfirm, onCancel }: ActionSectionProps) => {
+const ActionSection = ({ confirmLabel, onAllSelect, onConfirm, onCancel }: ActionSectionProps) => {
   return (
     <div className="flex w-full items-center justify-between font-medium text-gray-700">
       <button onClick={onAllSelect}>전체 선택</button>
       <div className="flex gap-[1rem]">
-        <button onClick={onConfirm}>확인</button>
+        <button onClick={onConfirm}>{confirmLabel}</button>
         <button onClick={onCancel} className="text-red-500">
           취소
         </button>

--- a/src/components/organisms/SelectModeDashboard/SelectModeDashboard.tsx
+++ b/src/components/organisms/SelectModeDashboard/SelectModeDashboard.tsx
@@ -9,6 +9,7 @@ type Props = {
   onAllSelect: () => Promise<void> | void;
   onConfirm: () => Promise<void> | void;
   onCancel: () => Promise<void> | void;
+  isSubmitting?: boolean;
 };
 
 export const SelectModeDashboard = ({
@@ -20,6 +21,7 @@ export const SelectModeDashboard = ({
   onAllSelect,
   onConfirm,
   onCancel,
+  isSubmitting = false,
 }: Props) => {
   return (
     <div className="fixed bottom-0 left-1/2 z-10 w-full -translate-x-1/2 bg-white shadow-[0_-8px_30px_rgb(0,0,0,0.2)] sm:max-w-[360px]">
@@ -38,6 +40,7 @@ export const SelectModeDashboard = ({
           onAllSelect={onAllSelect}
           onConfirm={onConfirm}
           onCancel={onCancel}
+          isSubmitting={isSubmitting}
         />
       </div>
     </div>
@@ -69,14 +72,23 @@ type ActionSectionProps = {
   onAllSelect: () => Promise<void> | void;
   onConfirm: () => Promise<void> | void;
   onCancel: () => Promise<void> | void;
+  isSubmitting: boolean;
 };
 
-const ActionSection = ({ confirmLabel, onAllSelect, onConfirm, onCancel }: ActionSectionProps) => {
+const ActionSection = ({
+  confirmLabel,
+  onAllSelect,
+  onConfirm,
+  onCancel,
+  isSubmitting,
+}: ActionSectionProps) => {
   return (
     <div className="flex w-full items-center justify-between font-medium text-gray-700">
       <button onClick={onAllSelect}>전체 선택</button>
       <div className="flex gap-[1rem]">
-        <button onClick={onConfirm}>{confirmLabel}</button>
+        <button disabled={isSubmitting} onClick={onConfirm}>
+          {confirmLabel}
+        </button>
         <button onClick={onCancel} className="text-red-500">
           취소
         </button>

--- a/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
+++ b/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
@@ -26,6 +26,8 @@ export const UserWordbookDetailPage = () => {
 
   // Delete mode
   const [deleteMode, setDeleteMode] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const isDeletingRef = useRef(false);
   const allWordIds = words.status === 'success' ? words.data.map((word) => word.id) : [];
   const { selectedIds, selectAll, toggle, clear } = useWordSelection(allWordIds);
 
@@ -173,10 +175,15 @@ export const UserWordbookDetailPage = () => {
   };
 
   const handleDeleteWords = async () => {
+    if (isDeletingRef.current) return;
+
     if (!wordbookId || selectedIds.size === 0) {
       alert('삭제할 단어를 선택해주세요.');
       return;
     }
+
+    isDeletingRef.current = true;
+    setIsDeleting(true);
 
     try {
       const requestedWordIds = Array.from(selectedIds);
@@ -208,6 +215,9 @@ export const UserWordbookDetailPage = () => {
     } catch (_) {
       // TODO: 에러 UI/UX 기획 필요
       alert('단어 삭제에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      isDeletingRef.current = false;
+      setIsDeleting(false);
     }
   };
 
@@ -253,6 +263,7 @@ export const UserWordbookDetailPage = () => {
       onDeleteWords={handleDeleteWords}
       onCancelDelete={clearDeleteMode}
       onOpenDeleteMode={handleOpenDeleteMode}
+      isDeleting={isDeleting}
     />
   );
 };

--- a/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
+++ b/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
@@ -180,8 +180,14 @@ export const UserWordbookDetailPage = () => {
 
     try {
       const requestedWordIds = Array.from(selectedIds);
-      const { wordIds: deletedWordIds } = await deleteUserWordList(wordbookId, requestedWordIds);
-      const deletedWordIdSet = new Set(deletedWordIds);
+      const { wordIds: responseDeletedWordIds } = await deleteUserWordList(
+        wordbookId,
+        requestedWordIds,
+      );
+      const requestedWordIdSet = new Set(requestedWordIds);
+      const deletedWordIdSet = new Set(
+        responseDeletedWordIds.filter((id) => requestedWordIdSet.has(id)),
+      );
 
       setWords((prev) => {
         if (prev.status !== 'success') return prev;
@@ -192,8 +198,8 @@ export const UserWordbookDetailPage = () => {
       });
       clearDeleteMode();
 
-      if (requestedWordIds.length !== deletedWordIds.length) {
-        const failedWordCount = requestedWordIds.length - deletedWordIds.length;
+      if (requestedWordIdSet.size !== deletedWordIdSet.size) {
+        const failedWordCount = requestedWordIdSet.size - deletedWordIdSet.size;
         alert(`${failedWordCount}개의 단어 삭제에 실패했습니다.`);
         return;
       }

--- a/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
+++ b/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
@@ -5,7 +5,8 @@ import { UserWordbookDetailPageTemplate } from '@/components/templates/UserWordb
 import { ROUTES } from '@/router/path';
 import { useNavigate, useParams } from 'react-router-dom';
 import type { AsyncState } from '@/shared/types/asyncState';
-import { createUserWord, getWordList } from '@/apis/word';
+import { createUserWord, deleteUserWordList, getWordList } from '@/apis/word';
+import { useWordSelection } from '@/hooks/useWordSelection';
 
 export const UserWordbookDetailPage = () => {
   const navigate = useNavigate();
@@ -22,6 +23,11 @@ export const UserWordbookDetailPage = () => {
   const [words, setWords] = useState<AsyncState<Word[]>>({ status: 'idle' });
   const [newWord, setNewWord] = useState<Word>(createEmptyWord());
   const { wordbookId } = useParams<{ wordbookId: string }>();
+
+  // Delete mode
+  const [deleteMode, setDeleteMode] = useState(false);
+  const allWordIds = words.status === 'success' ? words.data.map((word) => word.id) : [];
+  const { selectedIds, selectAll, toggle, clear } = useWordSelection(allWordIds);
 
   // Header kebab menu
   const [isKebabMenuOpen, setIsKebabMenuOpen] = useState<boolean>(false);
@@ -155,6 +161,50 @@ export const UserWordbookDetailPage = () => {
     openCreateWordModal(CREATE_WORD_MODAL_ID);
   };
 
+  const clearDeleteMode = () => {
+    setDeleteMode(false);
+    clear();
+  };
+
+  const handleOpenDeleteMode = () => {
+    handleKebabMenuOpen(false);
+    clear();
+    setDeleteMode(true);
+  };
+
+  const handleDeleteWords = async () => {
+    if (!wordbookId || selectedIds.size === 0) {
+      alert('삭제할 단어를 선택해주세요.');
+      return;
+    }
+
+    try {
+      const requestedWordIds = Array.from(selectedIds);
+      const { wordIds: deletedWordIds } = await deleteUserWordList(wordbookId, requestedWordIds);
+      const deletedWordIdSet = new Set(deletedWordIds);
+
+      setWords((prev) => {
+        if (prev.status !== 'success') return prev;
+        return {
+          status: 'success',
+          data: prev.data.filter((word) => !deletedWordIdSet.has(word.id)),
+        };
+      });
+      clearDeleteMode();
+
+      if (requestedWordIds.length !== deletedWordIds.length) {
+        const failedWordCount = requestedWordIds.length - deletedWordIds.length;
+        alert(`${failedWordCount}개의 단어 삭제에 실패했습니다.`);
+        return;
+      }
+
+      alert('단어 삭제에 성공했습니다.');
+    } catch (_) {
+      // TODO: 에러 UI/UX 기획 필요
+      alert('단어 삭제에 실패했습니다. 다시 시도해주세요.');
+    }
+  };
+
   const handleNavigate = () => {
     const path = ROUTES.WORDBOOKS; // TODO: '나의 단어장' 탭이 보여야 하는지 확인 필요
     navigate(path);
@@ -189,6 +239,14 @@ export const UserWordbookDetailPage = () => {
       onClose={resetCreateWordForm}
       onNavigate={handleNavigate}
       onOpenCreateWordModal={handleOpenCreateWordModal}
+      // delete word dashboard props
+      deleteMode={deleteMode}
+      selectedIds={selectedIds}
+      onToggleWordSelection={toggle}
+      onAllSelect={selectAll}
+      onDeleteWords={handleDeleteWords}
+      onCancelDelete={clearDeleteMode}
+      onOpenDeleteMode={handleOpenDeleteMode}
     />
   );
 };

--- a/src/components/templates/UserWordbookDetailPageTemplate/UserWordbookDetailPageTemplate.tsx
+++ b/src/components/templates/UserWordbookDetailPageTemplate/UserWordbookDetailPageTemplate.tsx
@@ -5,6 +5,7 @@ import { WordList } from '@/components/organisms/WordList/WordList';
 import { CreateWordModalContent } from '@/components/organisms/CreateWordModal/CreateWordModalContent';
 import type { PartOfSpeech, Word } from '@/domain/word';
 import { KebabMenu } from '@/components/organisms/KebabMenu/KebabMenu';
+import { SelectModeDashboard } from '@/components/organisms/SelectModeDashboard/SelectModeDashboard';
 
 interface Props {
   title?: string;
@@ -33,6 +34,15 @@ interface Props {
   /** Header actions */
   onNavigate: () => void;
   onOpenCreateWordModal: () => void;
+
+  /** Delete mode */
+  deleteMode: boolean;
+  selectedIds: Set<string>;
+  onToggleWordSelection: (id: string) => Promise<void> | void;
+  onAllSelect: () => Promise<void> | void;
+  onDeleteWords: () => Promise<void> | void;
+  onCancelDelete: () => Promise<void> | void;
+  onOpenDeleteMode: () => Promise<void> | void;
 }
 
 export const UserWordbookDetailPageTemplate = ({
@@ -54,6 +64,13 @@ export const UserWordbookDetailPageTemplate = ({
   onClose,
   onNavigate,
   onOpenCreateWordModal,
+  deleteMode,
+  selectedIds,
+  onToggleWordSelection,
+  onAllSelect,
+  onDeleteWords,
+  onCancelDelete,
+  onOpenDeleteMode,
 }: Props) => {
   return (
     <div className="flex h-full w-full flex-col bg-gray-100">
@@ -67,8 +84,32 @@ export const UserWordbookDetailPageTemplate = ({
         RCTARef={kebabAnchorRef}
       />
 
-      <div className="mt-[0.5rem] flex min-h-0 w-full flex-1 flex-col overflow-y-auto">
-        <WordList words={words} />
+      {deleteMode && (
+        <SelectModeDashboard
+          words={words}
+          title={`${title}`}
+          statusText="에서 삭제 중"
+          confirmLabel="삭제"
+          selectedIds={selectedIds}
+          onAllSelect={onAllSelect}
+          onConfirm={onDeleteWords}
+          onCancel={onCancelDelete}
+        />
+      )}
+
+      <div
+        className={`mt-[0.5rem] flex min-h-0 w-full flex-1 flex-col overflow-y-auto ${deleteMode ? 'pb-[6rem]' : ''}`}
+      >
+        {deleteMode ? (
+          <WordList
+            words={words}
+            mode="select"
+            selectedIds={selectedIds}
+            toggleWordSelection={onToggleWordSelection}
+          />
+        ) : (
+          <WordList words={words} />
+        )}
       </div>
 
       {/* 휘발성 오버레이 */}
@@ -83,7 +124,7 @@ export const UserWordbookDetailPageTemplate = ({
           },
           {
             label: '단어 삭제하기',
-            handleClick: () => alert('준비 중입니다.'),
+            handleClick: onOpenDeleteMode,
           },
           {
             label: '단어장 삭제하기',

--- a/src/components/templates/UserWordbookDetailPageTemplate/UserWordbookDetailPageTemplate.tsx
+++ b/src/components/templates/UserWordbookDetailPageTemplate/UserWordbookDetailPageTemplate.tsx
@@ -43,6 +43,7 @@ interface Props {
   onDeleteWords: () => Promise<void> | void;
   onCancelDelete: () => Promise<void> | void;
   onOpenDeleteMode: () => Promise<void> | void;
+  isDeleting: boolean;
 }
 
 export const UserWordbookDetailPageTemplate = ({
@@ -71,6 +72,7 @@ export const UserWordbookDetailPageTemplate = ({
   onDeleteWords,
   onCancelDelete,
   onOpenDeleteMode,
+  isDeleting,
 }: Props) => {
   return (
     <div className="flex h-full w-full flex-col bg-gray-100">
@@ -94,6 +96,7 @@ export const UserWordbookDetailPageTemplate = ({
           onAllSelect={onAllSelect}
           onConfirm={onDeleteWords}
           onCancel={onCancelDelete}
+          isSubmitting={isDeleting}
         />
       )}
 

--- a/src/components/templates/WordbookDetailPageTemplate/WordbookDetailPageTemplate.tsx
+++ b/src/components/templates/WordbookDetailPageTemplate/WordbookDetailPageTemplate.tsx
@@ -75,7 +75,8 @@ export const WordbookDetailPageTemplate = ({
       {selectMode && selectedWordbook && (
         <SelectModeDashboard
           words={words}
-          selectedWordbook={selectedWordbook}
+          title={selectedWordbook.title}
+          statusText="에 추가 중"
           selectedIds={selectedIds}
           onAllSelect={onAllSelect}
           onConfirm={onConfirm}


### PR DESCRIPTION
## 🫧 요약

- 사용자 단어 목록 삭제 API 연동

## ✅ 작업 내용

- 사용자 단어 단일 삭제 API 함수 작성
  - 추후 사용 가능성 있으므로 주석 처리
- 사용자 단어 목록 삭제 API 함수 작성 및 연동
  - 삭제 요청 id 개수와 응답 개수를 비교 -> 일치하지 않으면 "N개의 삭제 요청 실패" alert 보여주기
- SelectModeDashboard 문구 범용 처리 가능하도록 props 추가
  - ㅇㅇ 단어장에 단어 추가중/삭제중..

## 🧪 테스트 방법

- 나의 단어장 > 단어 삭제

## 📷 참고 자료 - 스크린샷 / 링크 / GIF / ...

## ❣️ 관련 이슈

- close #89

## ☝️ 참고 사항

- 참고하세요~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 단어장 상세에서 여러 단어를 선택해 한 번에 삭제할 수 있습니다.
  - 삭제 모드에서 개별 선택과 전체 선택을 지원합니다.
  - 삭제 진행 상태가 표시되고, 확인 버튼 문구가 상황에 맞게 변경됩니다.

- **개선 사항**
  - 단어 삭제 메뉴가 실제 삭제 모드로 정확히 연결되며, 삭제 결과에 따라 안내가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->