### PR TITLE
[FEAT] 사용자 단어장 삭제 API 연동

### DIFF
--- a/src/apis/wordbook/index.ts
+++ b/src/apis/wordbook/index.ts
@@ -34,3 +34,12 @@ export const createUserWordbook = async (
     throw error;
   }
 };
+
+export const deleteUserWordbook = async (wordbookId: string): Promise<void> => {
+  try {
+    await api.delete<void>(`/wordbooks/${wordbookId}`);
+  } catch (error) {
+    console.error('[ERROR] 사용자 단어장 삭제 실패: ', error);
+    throw error;
+  }
+};

--- a/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
+++ b/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
@@ -6,6 +6,7 @@ import { ROUTES } from '@/router/path';
 import { useNavigate, useParams } from 'react-router-dom';
 import type { AsyncState } from '@/shared/types/asyncState';
 import { createUserWord, getWordList } from '@/apis/word';
+import { deleteUserWordbook } from '@/apis/wordbook';
 
 export const UserWordbookDetailPage = () => {
   const navigate = useNavigate();
@@ -21,6 +22,8 @@ export const UserWordbookDetailPage = () => {
   });
   const [words, setWords] = useState<AsyncState<Word[]>>({ status: 'idle' });
   const [newWord, setNewWord] = useState<Word>(createEmptyWord());
+  const [isDeletingWordbook, setIsDeletingWordbook] = useState<boolean>(false);
+  const isDeletingWordbookRef = useRef<boolean>(false);
   const { wordbookId } = useParams<{ wordbookId: string }>();
 
   // Header kebab menu
@@ -155,6 +158,31 @@ export const UserWordbookDetailPage = () => {
     openCreateWordModal(CREATE_WORD_MODAL_ID);
   };
 
+  const handleDeleteWordbook = async () => {
+    if (!wordbookId || isDeletingWordbook || isDeletingWordbookRef.current) return;
+
+    setIsKebabMenuOpen(false);
+
+    const shouldDelete = window.confirm(
+      '단어장을 삭제하면 복구할 수 없습니다. 정말 삭제하시겠습니까?',
+    );
+    if (!shouldDelete) return;
+
+    isDeletingWordbookRef.current = true;
+    setIsDeletingWordbook(true);
+
+    try {
+      await deleteUserWordbook(wordbookId);
+      alert('단어장이 삭제되었습니다.');
+      navigate(ROUTES.WORDBOOKS);
+    } catch (_) {
+      alert('단어장 삭제에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      isDeletingWordbookRef.current = false;
+      setIsDeletingWordbook(false);
+    }
+  };
+
   const handleNavigate = () => {
     const path = ROUTES.WORDBOOKS; // TODO: '나의 단어장' 탭이 보여야 하는지 확인 필요
     navigate(path);
@@ -189,6 +217,7 @@ export const UserWordbookDetailPage = () => {
       onClose={resetCreateWordForm}
       onNavigate={handleNavigate}
       onOpenCreateWordModal={handleOpenCreateWordModal}
+      onDeleteWordbook={handleDeleteWordbook}
     />
   );
 };

--- a/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
+++ b/src/components/pages/UserWordbookDetailPage/UserWordbookDetailPage.tsx
@@ -161,6 +161,8 @@ export const UserWordbookDetailPage = () => {
   const handleDeleteWordbook = async () => {
     if (!wordbookId || isDeletingWordbook || isDeletingWordbookRef.current) return;
 
+    // TODO: confirm이 동기 블로킹이라 위 setState가 화면에 반영되기 전에 다이얼로그가 뜬다.
+    // 커스텀 모달로 교체하면 해소될 예정.
     setIsKebabMenuOpen(false);
 
     const shouldDelete = window.confirm(

--- a/src/components/templates/UserWordbookDetailPageTemplate/UserWordbookDetailPageTemplate.tsx
+++ b/src/components/templates/UserWordbookDetailPageTemplate/UserWordbookDetailPageTemplate.tsx
@@ -33,6 +33,7 @@ interface Props {
   /** Header actions */
   onNavigate: () => void;
   onOpenCreateWordModal: () => void;
+  onDeleteWordbook: () => Promise<void> | void;
 }
 
 export const UserWordbookDetailPageTemplate = ({
@@ -54,6 +55,7 @@ export const UserWordbookDetailPageTemplate = ({
   onClose,
   onNavigate,
   onOpenCreateWordModal,
+  onDeleteWordbook,
 }: Props) => {
   return (
     <div className="flex h-full w-full flex-col bg-gray-100">
@@ -87,7 +89,7 @@ export const UserWordbookDetailPageTemplate = ({
           },
           {
             label: '단어장 삭제하기',
-            handleClick: () => alert('준비 중입니다.'),
+            handleClick: onDeleteWordbook,
           },
         ]}
       />


### PR DESCRIPTION
## 🫧 요약

- 사용자 단어장 삭제 API 연동

## ✅ 작업 내용

- API 함수 정의
- 핸들러 중복 제출 방지
  - 삭제 경고는 브라우저 confirm을 이용해서 별도의 disabled 처리가 필요 없음
  - 추후 커스텀 모달로 변경될 수 있으므로 제출 중 ref, state 두었음

## 🧪 테스트 방법

- 나의 단어장 > Kebab > 단어장 삭제하기

## 📷 참고 자료 - 스크린샷 / 링크 / GIF / ...

## ❣️ 관련 이슈

- close #90

## ☝️ 참고 사항

- 참고하세요~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 단어장 상세 화면에서 단어장을 삭제할 수 있습니다.
  * 삭제 전 확인 절차가 제공되며, 삭제 완료 후 단어장 목록으로 이동합니다.
  * 삭제 처리 중 중복 요청을 방지합니다.
  * 삭제 성공 또는 실패 결과를 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->